### PR TITLE
page-header-bugs: Replace in breadcrumb the campaign-title with campaign-customer-title

### DIFF
--- a/src/pages/Bugs/PageHeader/index.tsx
+++ b/src/pages/Bugs/PageHeader/index.tsx
@@ -53,7 +53,7 @@ const BugsPageHeader = ({ campaignId }: { campaignId: number }) => {
               getLocalizeoFirstLevelDashboardRoute(campaignId);
           }}
         >
-          {campaign.title}
+          {campaign.customer_title}
         </Anchor>
       </PageHeader.Breadcrumb>
       <PageHeader.Main infoTitle={campaign.customer_title}>


### PR DESCRIPTION
- CONTEXT: Page header Bugs
- CHANGES: Replace at last breadcrumb the campaign title with campaign customer title