### PR TITLE
🐛 fix(BugStateDropdown.tsx): fix key prop warning by adding unique key to Separator component

### DIFF
--- a/src/common/components/BugDetail/BugStateDropdown.tsx
+++ b/src/common/components/BugDetail/BugStateDropdown.tsx
@@ -145,9 +145,9 @@ const BugStateDropdown = ({ bug }: { bug: Bug }) => {
           </Field>
           <Menu>
             {options &&
-              options.map((item, i) => (
+              options.map((item) => (
                 <>
-                  {i === 5 && <Separator />}
+                  {item.slug === 'solved' && <Separator />}
                   <StyledItem key={item.slug} value={item}>
                     {item.icon} {item.text}
                   </StyledItem>


### PR DESCRIPTION
🎨 style(BugStateDropdown.tsx): change map function parameter name from i to item for clarity
🎨 style(BugStateDropdown.tsx): add space between curly braces and ternary operator in map function