### PR TITLE
UN-997-click-on-u-icon-logo-in-header-not-redirecting-to-home-anymore

### DIFF
--- a/src/common/components/navigation/header/brandLogo.tsx
+++ b/src/common/components/navigation/header/brandLogo.tsx
@@ -1,4 +1,9 @@
-import { HeaderItem, HeaderItemIcon, HeaderItemText, Logo } from '@appquality/unguess-design-system';
+import {
+  HeaderItem,
+  HeaderItemIcon,
+  HeaderItemText,
+  Logo,
+} from '@appquality/unguess-design-system';
 import { useTranslation } from 'react-i18next';
 import { useAppDispatch } from 'src/app/hooks';
 import { toggleSidebar } from 'src/features/navigation/navigationSlice';


### PR DESCRIPTION
## Pull Request Description

This pull request adds support for navigating to the root route ("/") when the brand logo is clicked in the header component. Previously, clicking the logo did not trigger any action.

### Changes Made

- Imported the `useNavigate` hook from `react-router-dom`.
- Added the `navigate` variable using the `useNavigate` hook.
- Modified the `handleLogoClick` function to call `navigate('/')` to navigate to the root route.
- Updated the `BrandLogo` component to include the new functionality.