### PR TITLE
🔧 fix(getExcludeNotABugInfo.tsx): add missing properties to the returned object

### DIFF
--- a/src/common/components/utils/getExcludeNotABugInfo.tsx
+++ b/src/common/components/utils/getExcludeNotABugInfo.tsx
@@ -4,6 +4,9 @@ import { DEFAULT_NOT_A_BUG_CUSTOM_STATUS } from 'src/constants';
 export const getExcludeNotABugInfo = (t: TFunction) => ({
   customStatusId: DEFAULT_NOT_A_BUG_CUSTOM_STATUS.id,
   customStatusName: DEFAULT_NOT_A_BUG_CUSTOM_STATUS.name,
+  customStatusColor: DEFAULT_NOT_A_BUG_CUSTOM_STATUS.color,
+  customStatusPhase: DEFAULT_NOT_A_BUG_CUSTOM_STATUS.phase,
+  customStatusIsDefault: DEFAULT_NOT_A_BUG_CUSTOM_STATUS.is_default,
   actionIdentifier: 'excludeNotABug',
   recapTitle: t('__BUGS_EXCLUDED_NOT_A_BUG'),
   drawerTitle: t('__BUGS_EXCLUDE_NOT_A_BUG'),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,4 +56,10 @@ export const RELATIVE_DATE_FORMAT_OPTS: {
 export const DEFAULT_NOT_A_BUG_CUSTOM_STATUS = {
   id: 7,
   name: 'not a bug',
+  color: 'ffffff',
+  is_default: true,
+  phase: {
+    id: 1,
+    name: 'working',
+  },
 };

--- a/src/features/bugsPage/customStatusFilter.ts
+++ b/src/features/bugsPage/customStatusFilter.ts
@@ -1,9 +1,10 @@
 import { useAppSelector } from 'src/app/hooks';
+import { BugCustomStatus } from '../api';
 
 export type CustomStatusFilterType = {
   customStatuses: {
-    available: { id: number; name: string }[];
-    selected: { id: number; name: string }[];
+    available: BugCustomStatus[];
+    selected: BugCustomStatus[];
   };
 };
 
@@ -20,7 +21,7 @@ export const CustomStatusFilter = {
   }),
   setAvailable: (
     state: CustomStatusFilterType,
-    customStatuses: { id: number; name: string }[]
+    customStatuses: BugCustomStatus[]
   ) => ({
     customStatuses: {
       ...CustomStatusFilter.getCurrent(state),
@@ -29,7 +30,7 @@ export const CustomStatusFilter = {
   }),
   filter: (
     state: CustomStatusFilterType,
-    customStatuses?: { id: number; name: string }[]
+    customStatuses?: BugCustomStatus[]
   ) => ({
     customStatuses: {
       ...CustomStatusFilter.getCurrent(state),

--- a/src/pages/Bugs/Drawer/CustomStatusField.tsx
+++ b/src/pages/Bugs/Drawer/CustomStatusField.tsx
@@ -49,6 +49,9 @@ export const CustomStatusField = ({
         {
           id: customStatusNotABugInfo.actionIdentifier,
           name: customStatusNotABugInfo.drawerTitle,
+          color: customStatusNotABugInfo.customStatusColor,
+          phase: customStatusNotABugInfo.customStatusPhase,
+          is_default: customStatusNotABugInfo.customStatusIsDefault,
         },
       ]
     : [...selected];


### PR DESCRIPTION
🔧 fix(constants.ts): add missing properties to DEFAULT_NOT_A_BUG_CUSTOM_STATUS object
🔧 fix(customStatusFilter.ts): update type definitions to use BugCustomStatus interface
🔧 fix(CustomStatusField.tsx): add missing properties to custom status object