### PR TITLE
Refactor Navigation component to handle preference value as string

### DIFF
--- a/src/common/schema.ts
+++ b/src/common/schema.ts
@@ -415,6 +415,20 @@ export interface paths {
     };
   };
   '/videos/{vid}/translation': {
+    /** Return, if exists, a valid translation in the user preferred language or in the requested language (if provided) */
+    get: operations['get-videos-vid-translation'];
+    /**
+     * This endpoint generates a new translation for the provided video if it does not already exist.
+     *
+     * **Security**: Requires Bearer Authentication. Provide your bearer token in the Authorization header when making requests to protected resources. Example: Authorization: Bearer 123.
+     *
+     * **Path Parameters**:
+     *
+     * vid (string, required): The ID of the video for which the translation is to be generated.
+     * Request Body (application/json):
+     *
+     * language (string, required): The language code for the desired translation.
+     */
     post: operations['post-videos-vid-translation'];
     parameters: {
       path: {
@@ -975,7 +989,7 @@ export interface components {
     /** UserPreference */
     UserPreference: {
       preference_id: number;
-      value: number;
+      value: string;
       name: string;
     };
     /**
@@ -2856,7 +2870,7 @@ export interface operations {
     requestBody: {
       content: {
         'application/json': {
-          value: number;
+          value: string;
         };
       };
     };
@@ -2967,6 +2981,48 @@ export interface operations {
       };
     };
   };
+  /** Return, if exists, a valid translation in the user preferred language or in the requested language (if provided) */
+  'get-videos-vid-translation': {
+    parameters: {
+      path: {
+        vid: string;
+      };
+      query: {
+        /** language */
+        lang?: string;
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          'application/json': {
+            language: string;
+            sentences: {
+              text: string;
+              start: number;
+              end: number;
+            }[];
+          };
+        };
+      };
+      400: components['responses']['Error'];
+      403: components['responses']['Error'];
+      500: components['responses']['Error'];
+    };
+  };
+  /**
+   * This endpoint generates a new translation for the provided video if it does not already exist.
+   *
+   * **Security**: Requires Bearer Authentication. Provide your bearer token in the Authorization header when making requests to protected resources. Example: Authorization: Bearer 123.
+   *
+   * **Path Parameters**:
+   *
+   * vid (string, required): The ID of the video for which the translation is to be generated.
+   * Request Body (application/json):
+   *
+   * language (string, required): The language code for the desired translation.
+   */
   'post-videos-vid-translation': {
     parameters: {
       path: {
@@ -2977,13 +3033,7 @@ export interface operations {
       /** OK */
       200: {
         content: {
-          'application/json': {
-            sentences: {
-              start: number;
-              text: string;
-              end: number;
-            }[];
-          };
+          'application/json': { [key: string]: unknown };
         };
       };
       400: components['responses']['Error'];

--- a/src/features/api/index.ts
+++ b/src/features/api/index.ts
@@ -533,6 +533,15 @@ const injectedRtkApi = api.injectEndpoints({
         method: 'DELETE',
       }),
     }),
+    getVideosByVidTranslation: build.query<
+      GetVideosByVidTranslationApiResponse,
+      GetVideosByVidTranslationApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/videos/${queryArg.vid}/translation`,
+        params: { lang: queryArg.lang },
+      }),
+    }),
     postVideosByVidTranslation: build.mutation<
       PostVideosByVidTranslationApiResponse,
       PostVideosByVidTranslationApiArg
@@ -1415,7 +1424,7 @@ export type PutUsersMePreferencesByPrefidApiResponse =
 export type PutUsersMePreferencesByPrefidApiArg = {
   prefid: string;
   body: {
-    value: number;
+    value: string;
   };
 };
 export type GetVideosByVidApiResponse = /** status 200 OK */ Video & {
@@ -1460,13 +1469,20 @@ export type DeleteVideosByVidObservationsAndOidApiArg = {
   vid: string;
   oid: string;
 };
-export type PostVideosByVidTranslationApiResponse = /** status 200 OK */ {
+export type GetVideosByVidTranslationApiResponse = /** status 200 OK */ {
+  language: string;
   sentences: {
-    start: number;
     text: string;
+    start: number;
     end: number;
   }[];
 };
+export type GetVideosByVidTranslationApiArg = {
+  vid: string;
+  /** language */
+  lang?: string;
+};
+export type PostVideosByVidTranslationApiResponse = /** status 200 OK */ object;
 export type PostVideosByVidTranslationApiArg = {
   vid: string;
   body: {
@@ -2114,7 +2130,7 @@ export type User = {
 };
 export type UserPreference = {
   preference_id: number;
-  value: number;
+  value: string;
   name: string;
 };
 export type Workspace = {
@@ -2213,6 +2229,7 @@ export const {
   usePostVideosByVidObservationsMutation,
   usePatchVideosByVidObservationsAndOidMutation,
   useDeleteVideosByVidObservationsAndOidMutation,
+  useGetVideosByVidTranslationQuery,
   usePostVideosByVidTranslationMutation,
   useGetWorkspacesQuery,
   usePostWorkspacesMutation,

--- a/src/features/navigation/Navigation.tsx
+++ b/src/features/navigation/Navigation.tsx
@@ -65,7 +65,7 @@ export const Navigation = ({
   const onSetSettings = async (value: number) => {
     await updatePreference({
       prefid: `${notificationsPreference?.preference_id}`,
-      body: { value },
+      body: { value: value.toString() },
     })
       .unwrap()
       .then(() => {
@@ -153,7 +153,7 @@ export const Navigation = ({
       title: t('__PROFILE_MODAL_PRIVACY_ITEM_LABEL'),
       url: 'https://www.iubenda.com/privacy-policy/833252/full-legal',
     },
-    settingValue: notificationsPreference?.value,
+    settingValue: Number.parseInt(notificationsPreference?.value ?? '0', 10),
     i18n: {
       settingsTitle: t('__PROFILE_MODAL_NOTIFICATIONS_TITLE'),
       settingsIntroText: t('__PROFILE_MODAL_NOTIFICATIONS_INTRO'),


### PR DESCRIPTION
The Navigation component has been updated to handle the preference value as a string instead of a number. This change ensures compatibility with the API endpoint that expects a string value. Additionally, the `settingValue` property in the Navigation component has been updated to parse the preference value as an integer using `Number.parseInt()`. These changes improve the reliability and consistency of the Navigation component when handling user preferences.