### PR TITLE
Refactor UsecaseSection component to handle empty data

### DIFF
--- a/src/pages/Insights/Collection/components/UsecaseSection.tsx
+++ b/src/pages/Insights/Collection/components/UsecaseSection.tsx
@@ -54,6 +54,10 @@ export const UsecaseSection = ({
     [ungrouped, memoizedGrapes]
   );
 
+  if (memoizedGrapes.length === 0 && ungrouped.length === 0) {
+    return null;
+  }
+
   return (
     <StyledSection>
       <UsecaseTitle style={{ margin: `${appTheme.space.xs} 0` }}>


### PR DESCRIPTION
The UsecaseSection component has been refactored to handle cases where there is no data to display. Previously, the component would render an empty section, but now it returns null when both the memoizedGrapes and ungrouped arrays are empty. This improves the code by reducing unnecessary rendering and improves the user experience by not displaying empty sections.