### PR TITLE
Add disableMenuLanguageSettings option to navigation

### DIFF
--- a/src/features/navigation/Navigation.tsx
+++ b/src/features/navigation/Navigation.tsx
@@ -204,6 +204,7 @@ export const Navigation = ({
         { placement: 'top' }
       );
     },
+    disableMenuLanguageSettings: true,
   };
 
   const toggleSidebarState = () => {


### PR DESCRIPTION
This pull request adds the `disableMenuLanguageSettings` option to the navigation feature. This option allows the user to disable the language settings menu in the navigation component.