### PR TITLE
fix: Update column size in ReportRow for better responsiveness

### DIFF
--- a/src/pages/Campaign/useWidgets/Report/ReportRow.tsx
+++ b/src/pages/Campaign/useWidgets/Report/ReportRow.tsx
@@ -102,7 +102,13 @@ export const ReportRow = ({
                 />
               </Col>
             ) : (
-              <Col xs="auto">
+              <Col
+                xs={12}
+                sm={6}
+                md={4}
+                xl={3}
+                style={{ overflowWrap: 'anywhere' }}
+              >
                 <SpecialCard>
                   <SpecialCard.Meta
                     justifyContent="start"

--- a/src/pages/Campaign/useWidgets/Report/ReportRow.tsx
+++ b/src/pages/Campaign/useWidgets/Report/ReportRow.tsx
@@ -102,7 +102,7 @@ export const ReportRow = ({
                 />
               </Col>
             ) : (
-              <Col xs={12} sm={6} md={4} xl={3}>
+              <Col xs="auto">
                 <SpecialCard>
                   <SpecialCard.Meta
                     justifyContent="start"

--- a/src/pages/Campaign/useWidgets/Report/ReportRow.tsx
+++ b/src/pages/Campaign/useWidgets/Report/ReportRow.tsx
@@ -102,13 +102,7 @@ export const ReportRow = ({
                 />
               </Col>
             ) : (
-              <Col
-                xs={12}
-                sm={6}
-                md={4}
-                xl={3}
-                style={{ overflowWrap: 'anywhere' }}
-              >
+              <Col xs={12} sm={6} md={4} xl={3}>
                 <SpecialCard>
                   <SpecialCard.Meta
                     justifyContent="start"
@@ -142,7 +136,9 @@ export const ReportRow = ({
                       )}
                     </SpecialCard.Header.Label>
                     <SpecialCard.Header.Title>
-                      {report.title}
+                      <span style={{ overflowWrap: 'anywhere' }}>
+                        {report.title}
+                      </span>
                     </SpecialCard.Header.Title>
                   </SpecialCard.Header>
 


### PR DESCRIPTION
This pull request includes a small change to the `src/pages/Campaign/useWidgets/Report/ReportRow.tsx` file. The change improves the display of the report title by adding a `span` with `overflowWrap: 'anywhere'` to handle long titles more gracefully.

* [`src/pages/Campaign/useWidgets/Report/ReportRow.tsx`](diffhunk://#diff-9a17758ed6a97fa75c34679886f44cd8e883bbb9197bc121e8b049db4757d22dR139-R141): Added a `span` with `overflowWrap: 'anywhere'` around the `report.title` to improve the handling of long titles.