### PR TITLE
Update project settings invite message for user count

### DIFF
--- a/src/common/components/inviteUsers/projectSettings.tsx
+++ b/src/common/components/inviteUsers/projectSettings.tsx
@@ -264,10 +264,9 @@ export const ProjectSettings = () => {
                   ),
                 }}
                 values={{
-                  project_name: permissionSettingsTitle,
-                  project_url: projectRoute,
+                  users_count: usersCount,
                 }}
-                defaults="This project is shared with <span>{{users_count}}</span> people. Share the project with more people by sending them the link: <a href='{{project_url}}' target='_blank' rel='noreferrer'>{{project_name}}</a>."
+                defaults="Already shared with <span>{{users_count}}</span> people"
               />
             </Label>
             <FlexContainer


### PR DESCRIPTION
Revise the invite message in project settings to accurately reflect the current user count.