### PR TITLE
Update dossier language format in Express API

### DIFF
--- a/src/features/api/index.ts
+++ b/src/features/api/index.ts
@@ -258,6 +258,22 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({ url: `/campaigns/${queryArg.cid}/severities` }),
     }),
+    getCampaignsByCidSuggestions: build.query<
+      GetCampaignsByCidSuggestionsApiResponse,
+      GetCampaignsByCidSuggestionsApiArg
+    >({
+      query: (queryArg) => ({ url: `/campaigns/${queryArg.cid}/suggestions` }),
+    }),
+    postCampaignsByCidSuggestions: build.mutation<
+      PostCampaignsByCidSuggestionsApiResponse,
+      PostCampaignsByCidSuggestionsApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/campaigns/${queryArg.cid}/suggestions`,
+        method: 'POST',
+        body: queryArg.body,
+      }),
+    }),
     getCampaignsByCidTags: build.query<
       GetCampaignsByCidTagsApiResponse,
       GetCampaignsByCidTagsApiArg
@@ -722,7 +738,7 @@ export type PostCampaignsApiArg = {
     productType?: number;
     productLink?: string;
     browsers?: number[];
-    languages?: number[];
+    languages?: string[];
     outOfScope?: string;
     testerRequirements?: string;
     targetSize?: number;
@@ -1080,6 +1096,25 @@ export type GetCampaignsByCidSeveritiesApiResponse =
 export type GetCampaignsByCidSeveritiesApiArg = {
   /** Campaign id */
   cid: string;
+};
+export type GetCampaignsByCidSuggestionsApiResponse = /** status 200 OK */ {
+  suggestion?: {
+    slug: BannerType;
+    /** ServiceId from strapi */
+    serviceId?: number;
+  };
+};
+export type GetCampaignsByCidSuggestionsApiArg = {
+  /** Campaign id */
+  cid: string;
+};
+export type PostCampaignsByCidSuggestionsApiResponse = /** status 200 OK */ {};
+export type PostCampaignsByCidSuggestionsApiArg = {
+  /** Campaign id */
+  cid: string;
+  body: {
+    slug: BannerType;
+  };
 };
 export type GetCampaignsByCidTagsApiResponse = /** status 200 OK */ {
   tag_id: number;
@@ -1967,6 +2002,7 @@ export type Report = {
   creation_date?: string;
   update_date?: string;
 };
+export type BannerType = 'banner_testing_automation' | 'banner_user_experience';
 export type Tenant = {
   /** tryber wp_user_id */
   id: number;
@@ -2201,6 +2237,8 @@ export const {
   useGetCampaignsByCidReplicabilitiesQuery,
   useGetCampaignsByCidReportsQuery,
   useGetCampaignsByCidSeveritiesQuery,
+  useGetCampaignsByCidSuggestionsQuery,
+  usePostCampaignsByCidSuggestionsMutation,
   useGetCampaignsByCidTagsQuery,
   useGetCampaignsByCidUsecasesQuery,
   useGetCampaignsByCidUsersQuery,

--- a/src/pages/ExpressWizard/mapToCampaignFields.tsx
+++ b/src/pages/ExpressWizard/mapToCampaignFields.tsx
@@ -1,11 +1,11 @@
 export const mapLanguages = (language: string[]) =>
   language
     .map((lang) => {
-      if (lang === 'en') return 46;
-      if (lang === 'it') return 118;
-      return 0;
+      if (lang === 'en') return 'English';
+      if (lang === 'it') return 'Italian';
+      return '';
     })
-    .filter((id) => id > 0);
+    .filter((lang) => !lang);
 
 export const mapProductType = (productType: string) => {
   if (productType === 'webapp') return 1;


### PR DESCRIPTION
Refactor language handling to use string representations instead of numeric IDs and add new API endpoints for campaign suggestions.

Closes UN-476.