### PR TITLE
Refactor campaign filters to use testType object instead of testNameId

### DIFF
--- a/src/features/campaigns/index.ts
+++ b/src/features/campaigns/index.ts
@@ -29,7 +29,11 @@ export const selectFilteredCampaigns = (
       return false;
 
     // Check Test Type
-    if (filters.testNameId && type.id !== filters.testNameId) return false;
+    if (
+      filters.testType.label !== 'all' &&
+      type.id !== Number.parseInt(filters.testType.value, 10)
+    )
+      return false;
 
     // Check Search
     if (

--- a/src/features/campaignsFilter/campaignsFilterSlice.ts
+++ b/src/features/campaignsFilter/campaignsFilterSlice.ts
@@ -10,7 +10,10 @@ export const StatusFilters = {
 export interface FilterState {
   status: string;
   type: string;
-  testNameId: number;
+  testType: {
+    label: string;
+    value: string;
+  };
   search?: string;
   projectId?: number;
 }
@@ -18,7 +21,10 @@ export interface FilterState {
 const initialState: FilterState = {
   status: StatusFilters.All,
   type: 'all',
-  testNameId: 0,
+  testType: {
+    value: '0',
+    label: 'all',
+  },
 };
 
 const filtersSlice = createSlice({
@@ -32,7 +38,7 @@ const filtersSlice = createSlice({
       state.type = action.payload;
     },
     testTypeFilterChanged(state, action) {
-      state.testNameId = action.payload;
+      state.testType = action.payload;
     },
     searchFilterChanged(state, action) {
       state.search = action.payload;
@@ -43,7 +49,7 @@ const filtersSlice = createSlice({
     resetFilters(state) {
       state.status = initialState.status;
       state.type = initialState.type;
-      state.testNameId = initialState.testNameId;
+      state.testType = initialState.testType;
       state.search = initialState.search;
       state.projectId = initialState.projectId;
     },

--- a/src/pages/Dashboard/campaigns-list/useArchivedCampaigns.tsx
+++ b/src/pages/Dashboard/campaigns-list/useArchivedCampaigns.tsx
@@ -70,7 +70,11 @@ const useArchivedCampaigns = () => {
         return false;
 
       // Check Test Type
-      if (filters.testNameId && type.id !== filters.testNameId) return false;
+      if (
+        filters.testType.label !== 'all' &&
+        type.id !== Number.parseInt(filters.testType.value, 10)
+      )
+        return false;
 
       // Check Search
       if (

--- a/src/pages/Dashboard/campaigns-list/useCampaignsGroupedByProject.tsx
+++ b/src/pages/Dashboard/campaigns-list/useCampaignsGroupedByProject.tsx
@@ -49,8 +49,11 @@ const useCampaignsGroupedByProject = () => {
       if (filters.type !== 'all' && family.name.toLowerCase() !== filters.type)
         return false;
 
-      // Check Test Type
-      if (filters.testNameId && type.id !== filters.testNameId) return false;
+      if (
+        filters.testType.label !== 'all' &&
+        type.id !== Number.parseInt(filters.testType.value, 10)
+      )
+        return false;
 
       // Check Search
       if (

--- a/src/pages/Dashboard/emptyState.tsx
+++ b/src/pages/Dashboard/emptyState.tsx
@@ -30,14 +30,14 @@ export const EmptyResults = () => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
 
-  const { status, type, testNameId, search } = useAppSelector(
+  const { status, type, testType, search } = useAppSelector(
     (state) => state.filters
   );
 
   const hasFilters =
     status !== 'all' ||
     type !== 'all' ||
-    testNameId > 0 ||
+    testType.value !== 'all' ||
     (search && search !== '');
 
   return (

--- a/src/pages/Dashboard/filters/index.tsx
+++ b/src/pages/Dashboard/filters/index.tsx
@@ -1,5 +1,9 @@
 import { Col, Row } from '@appquality/unguess-design-system';
-import { selectStatuses, selectTestNames } from 'src/features/campaigns';
+import {
+  selectStatuses,
+  selectTestNames,
+  selectTypes,
+} from 'src/features/campaigns';
 import styled from 'styled-components';
 import { SearchInput } from './search';
 import { StatusDropdown } from './status';
@@ -58,7 +62,7 @@ export const Filters = ({ project_id }: { project_id?: number }) => {
           </Col>
           <Col xs={12} md={6} lg={3}>
             <FilterInputContainer>
-              <CampaignTypeDropdown />
+              <CampaignTypeDropdown availableTypes={selectTypes(filtered)} />
             </FilterInputContainer>
           </Col>
           <Col xs={12} md={6} lg={3}>

--- a/src/pages/Dashboard/filters/test.tsx
+++ b/src/pages/Dashboard/filters/test.tsx
@@ -12,7 +12,7 @@ export const TestTypeDropdown = ({
 }) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
-  const { testNameId } = useAppSelector((state) => state.filters);
+  const { testType } = useAppSelector((state) => state.filters);
 
   const items: DropdownItems = {
     0: {
@@ -30,19 +30,23 @@ export const TestTypeDropdown = ({
     });
   }
 
+  const selectedItem = items[testType.value] || testType;
+
   return (
     <Select
-      isPrimary={items[testNameId as number].value !== 'all'}
+      isPrimary={selectedItem.value !== 'all'}
       renderValue={() =>
         getItemText(
-          items[testNameId as number],
+          selectedItem,
           t('__DASHABOARD_CAMPAIGN_TEST_NAME_LABEL Max:10')
         )
       }
-      inputValue={items[testNameId as number].value}
-      selectionValue={items[testNameId as number].value}
+      inputValue={selectedItem.value}
+      selectionValue={selectedItem.value}
       onSelect={async (item) => {
-        dispatch(testTypeFilterChanged(item === 'all' ? 0 : Number(item)));
+        if (items[Number.parseInt(item, 10)]) {
+          dispatch(testTypeFilterChanged(items[Number.parseInt(item, 10)]));
+        }
       }}
     >
       {Object.keys(items).map((key) => (

--- a/src/pages/Dashboard/filters/type.tsx
+++ b/src/pages/Dashboard/filters/type.tsx
@@ -4,7 +4,11 @@ import { useAppDispatch, useAppSelector } from 'src/app/hooks';
 import { typeFilterChanged } from 'src/features/campaignsFilter/campaignsFilterSlice';
 import { DropdownItems, getItemText } from './utils';
 
-export const CampaignTypeDropdown = () => {
+export const CampaignTypeDropdown = ({
+  availableTypes,
+}: {
+  availableTypes: string[];
+}) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const { type } = useAppSelector((state) => state.filters);
@@ -43,6 +47,7 @@ export const CampaignTypeDropdown = () => {
         <Select.Option
           key={items[`${key}`].value}
           value={items[`${key}`].value}
+          isDisabled={availableTypes.indexOf(items[`${key}`].value) === -1}
           label={items[`${key}`].label}
         />
       ))}


### PR DESCRIPTION
Replace the testNameId with a testType object in the campaign filters, enhancing the filter functionality and improving code clarity.