### PR TITLE
fix: handle close for thank you page

### DIFF
--- a/src/pages/ExpressWizard/index.tsx
+++ b/src/pages/ExpressWizard/index.tsx
@@ -68,6 +68,8 @@ import { StepItem, useExpressStep } from './steps/useSteps';
 import { WizardHeader } from './wizardHeader';
 import defaultValues from './wizardInitialValues';
 import { WizardModel } from './wizardModel';
+import { useLocalizeRoute } from 'src/hooks/useLocalizedRoute';
+import { useNavigate } from 'react-router-dom';
 
 const StyledContainer = styled(ContainerCard)`
   position: sticky;
@@ -136,9 +138,11 @@ export const ExpressWizardContainer = () => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const formRef = useRef<FormikProps<{}>>(null);
+  const navigate = useNavigate();
   const [stepperTitle, setStepperTitle] = useState('');
   const { userData } = useAppSelector((state) => state.user);
   const { project } = useAppSelector((state) => state.express);
+  const projRoute = useLocalizeRoute(`projects/${project?.id}`);
   const { activeWorkspace } = useActiveWorkspace();
   const {
     isWizardOpen,
@@ -355,7 +359,16 @@ export const ExpressWizardContainer = () => {
 
   const [showDiscardChangesModal, setShowDiscardChangesModal] = useState(false);
   const closeExpressWizard = () => {
-    setShowDiscardChangesModal(true);
+    if (isWizardOpen) {
+      if (isThankyou) {
+        dispatch(closeDrawer());
+        dispatch(closeWizard());
+        dispatch(resetWizard());
+        navigate(projRoute);
+      } else {
+        setShowDiscardChangesModal(true);
+      }
+    }
   };
 
   useEffect(() => {

--- a/src/pages/ExpressWizard/index.tsx
+++ b/src/pages/ExpressWizard/index.tsx
@@ -54,6 +54,8 @@ import { useSendGTMevent } from 'src/hooks/useGTMevent';
 import i18n from 'src/i18n';
 import styled from 'styled-components';
 import * as Yup from 'yup';
+import { useLocalizeRoute } from 'src/hooks/useLocalizedRoute';
+import { useNavigate } from 'react-router-dom';
 import DiscardChangesModal from './ActionModals/DiscardChangesModal';
 import { getPlatform } from './getPlatform';
 import {
@@ -68,8 +70,6 @@ import { StepItem, useExpressStep } from './steps/useSteps';
 import { WizardHeader } from './wizardHeader';
 import defaultValues from './wizardInitialValues';
 import { WizardModel } from './wizardModel';
-import { useLocalizeRoute } from 'src/hooks/useLocalizedRoute';
-import { useNavigate } from 'react-router-dom';
 
 const StyledContainer = styled(ContainerCard)`
   position: sticky;


### PR DESCRIPTION
With this fix the confirmation modal is only shown during the steps and not in the thank you page.

Now if you click on close in the thank you page you'll have the same behavior as clicking the "Go to project" CTA.