### PR TITLE
feat: Update modal use case tab layout in ExpressWizard steps

### DIFF
--- a/src/pages/ExpressWizard/steps/express-3/ModalUseCase/modalUseCaseTabLayout.tsx
+++ b/src/pages/ExpressWizard/steps/express-3/ModalUseCase/modalUseCaseTabLayout.tsx
@@ -162,8 +162,8 @@ export const ModalUseCaseTabLayout = ({
                     {t(
                       '__EXPRESS_3_WIZARD_STEP_HOW_USE_CASE_MODAL_USE_CASE_LABEL'
                     )}{' '}
+                    {index + 1}
                   </CardTitle>
-                  {index + 1}
                 </UseCaseCard>
               ))}
             {use_cases && use_cases.length < EXPRESS_USE_CASES_LIMIT && (

--- a/src/pages/ExpressWizard/steps/express-4/ModalUseCase/modalUseCaseTabLayout.tsx
+++ b/src/pages/ExpressWizard/steps/express-4/ModalUseCase/modalUseCaseTabLayout.tsx
@@ -162,8 +162,8 @@ export const ModalUseCaseTabLayout = ({
                     {t(
                       '__EXPRESS_4_WIZARD_STEP_HOW_USE_CASE_MODAL_USE_CASE_LABEL'
                     )}{' '}
+                    {index + 1}
                   </CardTitle>
-                  {index + 1}
                 </UseCaseCard>
               ))}
             {use_cases && use_cases.length < EXPRESS_USE_CASES_LIMIT && (


### PR DESCRIPTION
This fixes the space between the label and the counter for the tabs in the use case modal in the express wizard.

![image](https://github.com/user-attachments/assets/08583251-e600-4ee7-88c4-f06329f95899)