### PR TITLE
fix: fix ScrollingGrid navigation arrows

### DIFF
--- a/src/common/components/ScrollingGrid.tsx
+++ b/src/common/components/ScrollingGrid.tsx
@@ -174,7 +174,7 @@ const ScrollingGridComponent = ({
   const scrollLeft = () => {
     if (scrollingContainer.current) {
       scrollingContainer.current.scrollBy({
-        left: -scrollingContainer.current.offsetWidth / 2,
+        left: -(scrollingContainer.current.offsetWidth / 2),
         behavior: 'smooth',
       });
     }
@@ -196,9 +196,10 @@ const ScrollingGridComponent = ({
         setIsLeftDisabled(false);
       }
       if (
-        scrollingContainer.current.scrollLeft +
-          scrollingContainer.current.offsetWidth >=
-        scrollingContainer.current.scrollWidth
+        Math.ceil(
+          scrollingContainer.current.scrollLeft +
+            scrollingContainer.current.offsetWidth
+        ) >= Math.ceil(scrollingContainer.current.scrollWidth)
       ) {
         setIsRightDisabled(true);
       } else {

--- a/src/common/components/ServiceTiles/index.tsx
+++ b/src/common/components/ServiceTiles/index.tsx
@@ -37,7 +37,7 @@ const ServiceTiles = () => {
         }}
       />
       <ExpressWizardContainer />
-      <ScrollingGrid>
+      <ScrollingGrid id="service-tiles-scrolling-grid">
         {data.map((template) => {
           const icon = <img alt={template.title || ''} src={template.icon} />;
           const superscript = template?.Price?.previous_price;

--- a/src/pages/Dashboard/SuggestedCampaigns.tsx
+++ b/src/pages/Dashboard/SuggestedCampaigns.tsx
@@ -44,7 +44,7 @@ export const SuggestedCampaigns = () => {
           </Paragraph>
         </Col>
       </Row>
-      <ScrollingGrid>
+      <ScrollingGrid id="suggested-campaigns-scrolling-grid">
         {campaigns.data.items.map((campaign) => (
           <ScrollingGrid.Item key={`suggested_${campaign.id}`}>
             <CampaignItem campaign={campaign} />


### PR DESCRIPTION
Math.ceil arrotonda sempre per eccesso il valore garantendo la validità del check se mostrare o meno la freccia destra/sinistra