### PR TITLE
feat: Add preventEmpty to InputToggle in EditableTitle component

### DIFF
--- a/src/pages/Campaign/pageHeader/EditableTitle.tsx
+++ b/src/pages/Campaign/pageHeader/EditableTitle.tsx
@@ -22,6 +22,7 @@ export const EditableTitle = ({ campaignId }: { campaignId: number }) => {
     () => (
       <InputToggle className="editable-title">
         <InputToggle.Item
+          preventEmpty
           textSize="xxxl"
           maxLength={64}
           value={itemTitle}

--- a/src/pages/Dashboard/EditableDescription.tsx
+++ b/src/pages/Dashboard/EditableDescription.tsx
@@ -1,0 +1,76 @@
+import {
+  InputToggle,
+  useToast,
+  Notification,
+} from '@appquality/unguess-design-system';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useGetProjectsByPidQuery,
+  usePatchProjectsByPidMutation,
+} from 'src/features/api';
+import { useSendGTMevent } from 'src/hooks/useGTMevent';
+
+export const EditableDescription = ({ projectId }: { projectId: number }) => {
+  const { t } = useTranslation();
+  const sendGTMEvent = useSendGTMevent();
+  const { addToast } = useToast();
+  const { data: project } = useGetProjectsByPidQuery({
+    pid: projectId.toString(),
+  });
+  const [itemDescription, setItemDescription] = useState<string>(
+    project?.description ?? ''
+  );
+
+  const [patchProject] = usePatchProjectsByPidMutation();
+
+  const InputToggleMemo = useMemo(
+    () => (
+      <InputToggle className="editable-title">
+        <InputToggle.Item
+          placeholder={t(
+            '__PROJECT_PAGE_UPDATE_PROJECT_DESCRIPTION_PLACEHOLDER'
+          )}
+          textSize="lg"
+          maxLength={64}
+          value={itemDescription}
+          onChange={(e) => setItemDescription(e.target.value)}
+          onBlur={async (e) => {
+            try {
+              if (e.currentTarget.value !== project?.description) {
+                await patchProject({
+                  pid: projectId?.toString() ?? '0',
+                  body: { description: e.currentTarget.value },
+                }).unwrap();
+                sendGTMEvent({
+                  event: 'workspaces-action',
+                  category: '',
+                  action: 'change_description_success',
+                  content: itemDescription,
+                });
+              }
+            } catch {
+              addToast(
+                ({ close }) => (
+                  <Notification
+                    onClose={close}
+                    type="error"
+                    message={t('__PROJECT_PAGE_UPDATE_PROJECT_NAME_ERROR')}
+                    closeText={t('__TOAST_CLOSE_TEXT')}
+                    isPrimary
+                  />
+                ),
+                { placement: 'top' }
+              );
+              setItemDescription(project?.description ?? '');
+            }
+          }}
+          style={{ paddingLeft: 0 }}
+        />
+      </InputToggle>
+    ),
+    [project, itemDescription]
+  );
+
+  return InputToggleMemo;
+};

--- a/src/pages/Dashboard/EditableDescription.tsx
+++ b/src/pages/Dashboard/EditableDescription.tsx
@@ -15,14 +15,11 @@ export const EditableDescription = ({ projectId }: { projectId: number }) => {
   const { t } = useTranslation();
   const sendGTMEvent = useSendGTMevent();
   const { addToast } = useToast();
+  const [patchProject] = usePatchProjectsByPidMutation();
   const { data: project } = useGetProjectsByPidQuery({
     pid: projectId.toString(),
   });
-  const [itemDescription, setItemDescription] = useState<string>(
-    project?.description ?? ''
-  );
-
-  const [patchProject] = usePatchProjectsByPidMutation();
+  const [itemDescription, setItemDescription] = useState<string>();
 
   const InputToggleMemo = useMemo(
     () => (
@@ -33,7 +30,7 @@ export const EditableDescription = ({ projectId }: { projectId: number }) => {
           )}
           textSize="lg"
           maxLength={64}
-          value={itemDescription}
+          value={project?.description}
           onChange={(e) => setItemDescription(e.target.value)}
           onBlur={async (e) => {
             try {

--- a/src/pages/Dashboard/EditableTitle.tsx
+++ b/src/pages/Dashboard/EditableTitle.tsx
@@ -15,12 +15,11 @@ export const EditableTitle = ({ projectId }: { projectId: number }) => {
   const { t } = useTranslation();
   const sendGTMEvent = useSendGTMevent();
   const { addToast } = useToast();
+  const [patchProject] = usePatchProjectsByPidMutation();
   const { data: project } = useGetProjectsByPidQuery({
     pid: projectId.toString(),
   });
-  const [itemTitle, setItemTitle] = useState<string>(project?.name ?? '');
-
-  const [patchProject] = usePatchProjectsByPidMutation();
+  const [itemTitle, setItemTitle] = useState<string>('');
 
   const InputToggleMemo = useMemo(
     () => (
@@ -29,7 +28,7 @@ export const EditableTitle = ({ projectId }: { projectId: number }) => {
           preventEmpty
           textSize="xxxl"
           maxLength={64}
-          value={itemTitle}
+          value={project?.name}
           onChange={(e) => setItemTitle(e.target.value)}
           onBlur={async (e) => {
             try {

--- a/src/pages/Dashboard/EditableTitle.tsx
+++ b/src/pages/Dashboard/EditableTitle.tsx
@@ -1,0 +1,75 @@
+import {
+  InputToggle,
+  useToast,
+  Notification,
+} from '@appquality/unguess-design-system';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useGetProjectsByPidQuery,
+  usePatchProjectsByPidMutation,
+} from 'src/features/api';
+import { useSendGTMevent } from 'src/hooks/useGTMevent';
+
+export const EditableTitle = ({ projectId }: { projectId: number }) => {
+  const { t } = useTranslation();
+  const sendGTMEvent = useSendGTMevent();
+  const { addToast } = useToast();
+  const { data: project } = useGetProjectsByPidQuery({
+    pid: projectId.toString(),
+  });
+  const [itemTitle, setItemTitle] = useState<string>(project?.name ?? '');
+
+  const [patchProject] = usePatchProjectsByPidMutation();
+
+  const InputToggleMemo = useMemo(
+    () => (
+      <InputToggle className="editable-title">
+        <InputToggle.Item
+          preventEmpty
+          textSize="xxxl"
+          maxLength={64}
+          value={itemTitle}
+          onChange={(e) => setItemTitle(e.target.value)}
+          onBlur={async (e) => {
+            try {
+              if (
+                e.currentTarget.value &&
+                e.currentTarget.value !== project?.name
+              ) {
+                await patchProject({
+                  pid: projectId?.toString() ?? '0',
+                  body: { display_name: e.currentTarget.value },
+                }).unwrap();
+                sendGTMEvent({
+                  event: 'workspaces-action',
+                  category: '',
+                  action: 'change_name_success',
+                  content: itemTitle,
+                });
+              }
+            } catch {
+              addToast(
+                ({ close }) => (
+                  <Notification
+                    onClose={close}
+                    type="error"
+                    message={t('__PROJECT_PAGE_UPDATE_PROJECT_NAME_ERROR')}
+                    closeText={t('__TOAST_CLOSE_TEXT')}
+                    isPrimary
+                  />
+                ),
+                { placement: 'top' }
+              );
+              setItemTitle(project?.name ?? '');
+            }
+          }}
+          style={{ paddingLeft: 0 }}
+        />
+      </InputToggle>
+    ),
+    [project, itemTitle]
+  );
+
+  return InputToggleMemo;
+};

--- a/src/pages/Dashboard/projectPageHeader.tsx
+++ b/src/pages/Dashboard/projectPageHeader.tsx
@@ -1,28 +1,21 @@
 import {
-  InputToggle,
   LG,
-  Message,
-  Notification,
   PageHeader,
   Skeleton,
-  useToast,
   XXXL,
 } from '@appquality/unguess-design-system';
-import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAppSelector } from 'src/app/hooks';
 import { appTheme } from 'src/app/theme';
 import { LayoutWrapper } from 'src/common/components/LayoutWrapper';
 import { ProjectSettings } from 'src/common/components/inviteUsers/projectSettings';
-import {
-  useGetProjectsByPidQuery,
-  usePatchProjectsByPidMutation,
-} from 'src/features/api';
-import { useSendGTMevent } from 'src/hooks/useGTMevent';
+import { useGetProjectsByPidQuery } from 'src/features/api';
 import { useLocalizeRoute } from 'src/hooks/useLocalizedRoute';
 import styled from 'styled-components';
 import { Counters } from './Counters';
+import { EditableTitle } from './EditableTitle';
+import { EditableDescription } from './EditableDescription';
 
 const StyledPageHeaderMeta = styled(PageHeader.Meta)`
   justify-content: space-between;
@@ -42,32 +35,20 @@ const StyledPageHeaderMeta = styled(PageHeader.Meta)`
 `;
 
 export const ProjectPageHeader = ({ projectId }: { projectId: number }) => {
-  type AnalyticsType = 'ChangeDescription' | 'ChangeTitle';
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { addToast } = useToast();
   const notFoundRoute = useLocalizeRoute('oops');
   const location = useLocation();
   const { status } = useAppSelector((state) => state.user);
-  const [itemTitle, setItemTitle] = useState<string>();
-  const [itemDescription, setItemDescription] = useState<string>();
 
   const {
     isLoading,
     isFetching,
     isError,
-    isSuccess,
     data: project,
   } = useGetProjectsByPidQuery({
     pid: projectId.toString(),
   });
-
-  useEffect(() => {
-    if (isSuccess && project) {
-      setItemTitle(project.name);
-      setItemDescription(project.description);
-    }
-  }, [project]);
 
   if (isError) {
     navigate(notFoundRoute, {
@@ -75,146 +56,24 @@ export const ProjectPageHeader = ({ projectId }: { projectId: number }) => {
     });
   }
 
-  const [patchProject] = usePatchProjectsByPidMutation();
-  const sendGTMEvent = useSendGTMevent();
-
-  const sendAnalyticEvents = (e: AnalyticsType) => {
-    switch (e) {
-      case 'ChangeDescription':
-        sendGTMEvent({
-          event: 'workspaces-action',
-          category: '',
-          action: 'change_description_success',
-          content: itemDescription,
-        });
-        break;
-      case 'ChangeTitle':
-        sendGTMEvent({
-          event: 'workspaces-action',
-          category: '',
-          action: 'change_name_success',
-          content: itemTitle,
-        });
-        break;
-      default:
-    }
-  };
-
-  const InputToggleMemoDescription = useMemo(
-    () => (
-      <InputToggle>
-        <InputToggle.Item
-          textSize="lg"
-          placeholder={t(
-            '__PROJECT_PAGE_UPDATE_PROJECT_DESCRIPTION_PLACEHOLDER',
-            'Write a description'
-          )}
-          value={itemDescription}
-          onChange={(e) => setItemDescription(e.target.value)}
-          onBlur={async (e) => {
-            try {
-              if (
-                e.currentTarget.value !== project?.description &&
-                e.currentTarget.value.length <= 234
-              ) {
-                await patchProject({
-                  pid: projectId.toString(),
-                  body: { description: e.currentTarget.value ?? '' },
-                }).unwrap();
-                sendAnalyticEvents('ChangeDescription');
-              }
-            } catch {
-              // eslint-disable-next-line
-              alert(
-                t('__PROJECT_PAGE_UPDATE_PROJECT_DESCRIPTION_ERROR', 'Error')
-              );
-            }
-          }}
-          style={{ paddingLeft: 0 }}
-        />
-        {itemDescription && itemDescription.length > 234 && (
-          <Message validation="error" style={{ marginTop: '8px' }}>
-            {t('__PROJECT_PAGE_UPDATE_PROJECT_DESCRIPTION_MAX_LENGTH')}
-          </Message>
-        )}
-      </InputToggle>
-    ),
-    [project, itemDescription]
-  );
-
-  // Memoize InputToggle component to avoid re-rendering
-  const InputToggleMemoTitle = useMemo(
-    () => (
-      <InputToggle>
-        <InputToggle.Item
-          placeholder=""
-          textSize="xxxl"
-          value={itemTitle}
-          onChange={(e) => setItemTitle(e.target.value)}
-          onBlur={async (e) => {
-            try {
-              if (
-                e.currentTarget.value &&
-                e.currentTarget.value !== project?.name &&
-                e.currentTarget.value.length <= 64
-              ) {
-                await patchProject({
-                  pid: projectId.toString(),
-                  body: { display_name: e.currentTarget.value },
-                }).unwrap();
-                sendAnalyticEvents('ChangeTitle');
-              }
-            } catch {
-              addToast(
-                ({ close }) => (
-                  <Notification
-                    onClose={close}
-                    type="error"
-                    message={t('__PROJECT_PAGE_UPDATE_PROJECT_NAME_ERROR')}
-                    closeText={t('__TOAST_CLOSE_TEXT')}
-                    isPrimary
-                  />
-                ),
-                { placement: 'top' }
-              );
-              setItemTitle(project?.name);
-            }
-          }}
-          style={{ paddingLeft: 0 }}
-        />
-        {itemTitle?.length === 0 && (
-          <Message validation="error" style={{ marginTop: '8px' }}>
-            {t(
-              '__PROJECT_PAGE_UPDATE_PROJECT_NAME_REQUIRED',
-              'Mandatory field'
-            )}
-          </Message>
-        )}
-        {itemTitle && itemTitle.length > 64 && (
-          <Message validation="error" style={{ marginTop: '8px' }}>
-            {t('__PROJECT_PAGE_UPDATE_PROJECT_NAME_MAX_LENGTH')}
-          </Message>
-        )}
-      </InputToggle>
-    ),
-    [project, itemTitle]
-  );
   const titleContent = project?.is_archive ? (
     <XXXL isBold>{project.name}</XXXL>
   ) : (
-    InputToggleMemoTitle
+    <EditableTitle projectId={projectId} />
   );
+
   const descriptionContent = project?.is_archive ? (
     <LG color={appTheme.palette.grey[700]}>
       {t('__PROJECT_PAGE_ARCHIVE_DESCRIPTION')}
     </LG>
   ) : (
-    InputToggleMemoDescription
+    <EditableDescription projectId={projectId} />
   );
+
   return (
     <LayoutWrapper>
       <PageHeader>
-        <PageHeader.Main mainTitle={itemTitle || ''}>
+        <PageHeader.Main mainTitle={project?.name || ''}>
           <PageHeader.Title style={{ minHeight: '62px' }}>
             {isLoading || isFetching || status === 'loading' ? (
               <Skeleton width="60%" height="44px" />


### PR DESCRIPTION
Add the preventEmpty prop to the InputToggle component in the EditableTitle component. This ensures that the input value cannot be empty. The change helps improve the user experience by preventing the submission of empty values.

fix: Update EditableDescription component

Create a new EditableDescription component that allows users to edit the project description. The component includes an InputToggle with a placeholder and a character limit of 64. The component also handles the onBlur event to update the project description via an API call. If the API call fails, an error notification is displayed.

fix: Update EditableTitle component

Create a new EditableTitle component that allows users to edit the project title. The component includes an InputToggle with a character limit of 64. The component also handles the onBlur event to update the project title via an API call. If the API call fails, an error notification is displayed.

refactor: Remove unused imports and variables

Remove unused imports and variables from the projectPageHeader component to improve code cleanliness and maintainability.