### PR TITLE
Rename testDescription to goal in ExpressWizardContainer campaign call

### DIFF
--- a/src/pages/ExpressWizard/index.tsx
+++ b/src/pages/ExpressWizard/index.tsx
@@ -269,7 +269,7 @@ export const ExpressWizardContainer = () => {
           languages: mapLanguages([values.campaign_language || '']),
           productType: mapProductType(values.product_type || ''),
           browsers: mapBrowsers(values),
-          testDescription: values.test_description,
+          goal: values.test_description,
           testerRequirements: mapTesterRequirements(values),
           targetSize: values.target_size,
         },


### PR DESCRIPTION
Update the campaign call in ExpressWizardContainer to use 'goal' instead of 'testDescription' for clarity.