### PR TITLE
fix: persistent thankyou page

### DIFF
--- a/src/pages/ExpressWizard/index.tsx
+++ b/src/pages/ExpressWizard/index.tsx
@@ -191,6 +191,7 @@ export const ExpressWizardContainer = () => {
   const onNext = () => {
     if (activeStep === steps.length - 1) {
       setThankyou(true);
+      setStep(0);
     } else if (formRef.current) {
       formRef.current?.validateForm().then((errors) => {
         if (formRef.current?.isValid) {


### PR DESCRIPTION
reset step to 0 upon reaching the thank you screen in ExpressWizardContainer