### PR TITLE
Ensure submission state resets and add data-qa attribute for confirm button

### DIFF
--- a/src/pages/Plan/Controls.tsx
+++ b/src/pages/Plan/Controls.tsx
@@ -85,6 +85,7 @@ export const Controls = () => {
                 setIsSubmitted(false);
               });
           }}
+          data-qa="confirm-activity-cta"
         >
           {t('__PLAN_PAGE_SUMMARY_TAB_CONFIRMATION_CARD_CONFIRM_CTA')}
         </Button>

--- a/src/pages/Plan/summary/components/ConfirmationCard.tsx
+++ b/src/pages/Plan/summary/components/ConfirmationCard.tsx
@@ -94,8 +94,11 @@ export const ConfirmationCard = () => {
               wid: activeWorkspace?.id.toString() ?? '',
               pid: planId?.toString() ?? '',
               body: { status: 'draft' },
-            }).unwrap();
-            setIsSubmitted(false);
+            })
+              .unwrap()
+              .then(() => {
+                setIsSubmitted(false);
+              });
           }}
         >
           {t('__PLAN_PAGE_SUMMARY_TAB_CONFIRMATION_CARD_REFUSE_CTA')}

--- a/tests/e2e/plan/pending_review.spec.ts
+++ b/tests/e2e/plan/pending_review.spec.ts
@@ -14,33 +14,24 @@ test.describe('A Plan page in pending request', () => {
     await moduleBuilderPage.open();
   });
 
-  test('has the quotation cta and the save button disabled', async () => {
+  test('has only the confirm button visible', async () => {
     await expect(
       moduleBuilderPage.elements().saveConfigurationCTA()
+    ).not.toBeVisible();
+    await expect(
+      moduleBuilderPage.elements().confirmActivityCTA()
     ).toBeVisible();
     await expect(
-      moduleBuilderPage.elements().saveConfigurationCTA()
-    ).toBeDisabled();
-    await expect(
-      moduleBuilderPage.elements().requestQuotationCTA()
-    ).toBeVisible();
-    await expect(
-      moduleBuilderPage.elements().requestQuotationCTA()
+      moduleBuilderPage.elements().confirmActivityCTA()
     ).toBeDisabled();
   });
   test('all inputs should be readonly', async () => {
     await expect(
       moduleBuilderPage.elements().saveConfigurationCTA()
-    ).toBeVisible();
-    await expect(
-      moduleBuilderPage.elements().saveConfigurationCTA()
-    ).toBeDisabled();
+    ).not.toBeVisible();
     await expect(
       moduleBuilderPage.elements().requestQuotationCTA()
-    ).toBeVisible();
-    await expect(
-      moduleBuilderPage.elements().requestQuotationCTA()
-    ).toBeDisabled();
+    ).not.toBeVisible();
   });
 
   // posso tornare indietro dal preventivo?

--- a/tests/fixtures/Plan.ts
+++ b/tests/fixtures/Plan.ts
@@ -55,6 +55,8 @@ export class PlanPage extends UnguessPage {
         this.page.getByRole('button', {
           name: this.i18n.t('__PLAN_REQUEST_QUOTATION_CTA'),
         }),
+      confirmActivityCTA: () =>
+        this.elements().pageHeader().getByTestId('confirm-activity-cta'),
       requestQuotationModalCTA: () =>
         this.page.getByTestId('request-quotation-modal-cta'),
       requestQuotationErrorMessage: () =>


### PR DESCRIPTION
Update the ConfirmationCard component to reset the submission state after a draft status update. Add a data-qa attribute to the confirm activity button for improved testability. Update tests to reflect these changes.