### PR TITLE
Conditionally display error messages in notes based on plan status

### DIFF
--- a/src/pages/Plan/modules/InstructionsNote.tsx
+++ b/src/pages/Plan/modules/InstructionsNote.tsx
@@ -122,19 +122,20 @@ const InstructionsNote = () => {
           >
             {value?.output}
           </Editor>
-          {hasFeatureFlag(FEATURE_FLAG_CHANGE_MODULES_VARIANTS) && (
-            <StyledInfoBox>
-              {error && typeof error === 'string' ? (
-                <Message validation="error" data-qa="instruction-note-error">
-                  {error}
-                </Message>
-              ) : (
-                <Message>
-                  {t('__PLAN_PAGE_MODULE_INSTRUCTION_NOTE_INFO')}
-                </Message>
-              )}
-            </StyledInfoBox>
-          )}
+          {hasFeatureFlag(FEATURE_FLAG_CHANGE_MODULES_VARIANTS) &&
+            getPlanStatus() === 'draft' && (
+              <StyledInfoBox>
+                {error && typeof error === 'string' ? (
+                  <Message validation="error" data-qa="instruction-note-error">
+                    {error}
+                  </Message>
+                ) : (
+                  <Message>
+                    {t('__PLAN_PAGE_MODULE_INSTRUCTION_NOTE_INFO')}
+                  </Message>
+                )}
+              </StyledInfoBox>
+            )}
         </>
       </StyledCard>
       {isOpenDeleteModal && (

--- a/src/pages/Plan/modules/SetupNote.tsx
+++ b/src/pages/Plan/modules/SetupNote.tsx
@@ -122,19 +122,20 @@ const SetupNote = () => {
           >
             {value?.output}
           </Editor>
-          {hasFeatureFlag(FEATURE_FLAG_CHANGE_MODULES_VARIANTS) && (
-            <StyledInfoBox>
-              {error && typeof error === 'string' ? (
-                <Message validation="error" data-qa="instruction-note-error">
-                  {error}
-                </Message>
-              ) : (
-                <Message>
-                  {t('__PLAN_PAGE_MODULE_INSTRUCTION_NOTE_INFO')}
-                </Message>
-              )}
-            </StyledInfoBox>
-          )}
+          {hasFeatureFlag(FEATURE_FLAG_CHANGE_MODULES_VARIANTS) &&
+            getPlanStatus() === 'draft' && (
+              <StyledInfoBox>
+                {error && typeof error === 'string' ? (
+                  <Message validation="error" data-qa="instruction-note-error">
+                    {error}
+                  </Message>
+                ) : (
+                  <Message>
+                    {t('__PLAN_PAGE_MODULE_INSTRUCTION_NOTE_INFO')}
+                  </Message>
+                )}
+              </StyledInfoBox>
+            )}
         </>
       </StyledCard>
       {isOpenDeleteModal && (

--- a/src/pages/Plan/modules/TargetNote.tsx
+++ b/src/pages/Plan/modules/TargetNote.tsx
@@ -122,19 +122,20 @@ const TargetNote = () => {
           >
             {value?.output}
           </Editor>
-          {hasFeatureFlag(FEATURE_FLAG_CHANGE_MODULES_VARIANTS) && (
-            <StyledInfoBox>
-              {error && typeof error === 'string' ? (
-                <Message validation="error" data-qa="instruction-note-error">
-                  {error}
-                </Message>
-              ) : (
-                <Message>
-                  {t('__PLAN_PAGE_MODULE_INSTRUCTION_NOTE_INFO')}
-                </Message>
-              )}
-            </StyledInfoBox>
-          )}
+          {hasFeatureFlag(FEATURE_FLAG_CHANGE_MODULES_VARIANTS) &&
+            getPlanStatus() === 'draft' && (
+              <StyledInfoBox>
+                {error && typeof error === 'string' ? (
+                  <Message validation="error" data-qa="instruction-note-error">
+                    {error}
+                  </Message>
+                ) : (
+                  <Message>
+                    {t('__PLAN_PAGE_MODULE_INSTRUCTION_NOTE_INFO')}
+                  </Message>
+                )}
+              </StyledInfoBox>
+            )}
         </>
       </StyledCard>
       {isOpenDeleteModal && (


### PR DESCRIPTION
Update the InstructionsNote, SetupNote, and TargetNote components to show error messages only when the plan status is 'draft'.