### PR TITLE
UN-1037 removed info message and icon from targetsize

### DIFF
--- a/src/pages/Plan/modules/TargetSize.tsx
+++ b/src/pages/Plan/modules/TargetSize.tsx
@@ -11,7 +11,6 @@ import { ChangeEvent, useEffect, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { appTheme } from 'src/app/theme';
 import { ReactComponent as AlertIcon } from 'src/assets/icons/alert-icon.svg';
-import { ReactComponent as InfoIcon } from 'src/assets/icons/info-icon.svg';
 import { ReactComponent as TrashIcon } from 'src/assets/icons/trash-stroke.svg';
 import { components } from 'src/common/schema';
 import { FEATURE_FLAG_CHANGE_MODULES_VARIANTS } from 'src/constants';
@@ -97,7 +96,7 @@ const TargetSize = () => {
           </AccordionNew.Header>
           <AccordionNew.Panel>
             <div style={{ padding: appTheme.space.xs }}>
-              <FormField style={{ marginBottom: appTheme.space.md }}>
+              <FormField>
                 <Label>
                   <Trans i18nKey="__PLAN_PAGE_MODULE_TARGET_LABEL">
                     Enter the number of users you want to include
@@ -115,7 +114,7 @@ const TargetSize = () => {
                   placeholder={t('__PLAN_PAGE_MODULE_TARGET_PLACEHOLDER')}
                 />
                 <StyledInfoBox>
-                  {error && typeof error === 'string' ? (
+                  {error && typeof error === 'string' && (
                     <>
                       <AlertIcon />
                       <SM
@@ -123,13 +122,6 @@ const TargetSize = () => {
                         data-qa="target-error"
                       >
                         {error}
-                      </SM>
-                    </>
-                  ) : (
-                    <>
-                      <InfoIcon />
-                      <SM style={{ color: appTheme.palette.grey[600] }}>
-                        {t('__PLAN_PAGE_MODULE_TARGET_INFO')}
                       </SM>
                     </>
                   )}


### PR DESCRIPTION
This pull request includes several changes to the `TargetSize` component in the `src/pages/Plan/modules/TargetSize.tsx` file. The most important changes include removing an unused import, updating the `FormField` component's styling, and simplifying the error handling logic.

### Codebase simplification:

* Removed the unused import of `InfoIcon` from the `src/assets/icons/info-icon.svg` file.
* Updated the `FormField` component to remove the inline `marginBottom` style.
* Simplified the error handling logic by removing the conditional rendering of the `InfoIcon` and associated message when there is no error. [[1]](diffhunk://#diff-6b20956ee1d03e3f43ed962fed1598e665096c389edde1bbdb918374b77703b4L118-R117) [[2]](diffhunk://#diff-6b20956ee1d03e3f43ed962fed1598e665096c389edde1bbdb918374b77703b4L128-L134)