### PR TITLE
UN-1042 fix: remove numbering from module titles in aside navigation

### DIFF
--- a/src/pages/Plan/modules/Tasks/parts/nav/TaskItemNav.tsx
+++ b/src/pages/Plan/modules/Tasks/parts/nav/TaskItemNav.tsx
@@ -83,7 +83,7 @@ const TaskItemNav = ({
           {getIconFromTaskOutput(task)}
           <Ellipsis style={{ width: '95%' }}>
             <MD>
-              {key + 1}.
+              {key + 1}.{' '}
               <Span isBold>
                 {hasPlaceholder
                   ? t('__PLAN_PAGE_MODULE_TASKS_TASK_TITLE_PLACEHOLDER_EMPTY')

--- a/src/pages/Plan/navigation/aside/NavBody.tsx
+++ b/src/pages/Plan/navigation/aside/NavBody.tsx
@@ -31,8 +31,8 @@ const NavBody = () => {
       <BodyContainer data-qa={`plans-nav-${activeTab}`}>
         {currentModules
           .filter((module) => availableModules.includes(module))
-          .map((module, index) => (
-            <NavItem index={index} type={module}>
+          .map((module) => (
+            <NavItem type={module}>
               {MODULES_WITH_OUTPUT.includes(module) && (
                 <NavItemChildren key={module} type={module} />
               )}

--- a/src/pages/Plan/navigation/aside/NavItem.tsx
+++ b/src/pages/Plan/navigation/aside/NavItem.tsx
@@ -80,7 +80,7 @@ const NavItem = ({
           {getIconFromModuleType(type)}
           <Ellipsis style={{ width: '95%' }}>
             <MD>
-              {index + 1}. <Span isBold>{getTitleFromModuleType(type)}</Span>
+              <Span isBold>{getTitleFromModuleType(type)}</Span>
             </MD>
           </Ellipsis>
         </StyledContainer>

--- a/src/pages/Plan/navigation/aside/NavItem.tsx
+++ b/src/pages/Plan/navigation/aside/NavItem.tsx
@@ -38,11 +38,9 @@ const NavItemLink = styled(Link)`
 
 const NavItem = ({
   type,
-  index,
   children,
 }: {
   type: components['schemas']['Module']['type'];
-  index: number;
   children?: React.ReactNode;
 }) => {
   const { t } = useTranslation();


### PR DESCRIPTION
This pull request includes minor changes to the formatting of task and navigation item displays in the `src/pages/Plan` module.

Formatting adjustments:

* [`src/pages/Plan/modules/Tasks/parts/nav/TaskItemNav.tsx`](diffhunk://#diff-14bf84fa152f4f52c4b65763391d4a36292e52da9b6fc06a6f38ab88d58ff73dL86-R86): Added a space after the task number for improved readability.
* [`src/pages/Plan/navigation/aside/NavItem.tsx`](diffhunk://#diff-5dd0c890b8ac5a11054f6e4ad74da75e74635d4eeeda83e67bcf9a4a0695100aL83-R83): Removed the task number and adjusted the bold styling to only apply to the module title.