### PR TITLE
UN-1036: fix closed sidebar on "templates" click

### DIFF
--- a/src/features/navigation/Navigation.tsx
+++ b/src/features/navigation/Navigation.tsx
@@ -105,8 +105,6 @@ export const Navigation = ({
         dispatch(setSidebarOpen(false));
         break;
       case 'templates':
-        dispatch(setSidebarOpen(false));
-        break;
       case 'template':
         dispatch(setSidebarOpen(false));
         break;


### PR DESCRIPTION
This pull request includes a minor change to the `Navigation` component in the `src/features/navigation/Navigation.tsx` file. The change removes redundant code that closes the sidebar when the 'templates' case is encountered, as this action is already handled in other cases. 

Codebase simplification:

* [`src/features/navigation/Navigation.tsx`](diffhunk://#diff-e9240292d73f667d69b58fba444826035d6f7eb444d33a6cabf6985f3b7bf391L108-L109): Removed the redundant `dispatch(setSidebarOpen(false));` and `break;` statements in the 'templates' case.