### PR TITLE
UN-1081:  update text in Experiential, Functional, Survey tasks

### DIFF
--- a/src/pages/Plan/modules/Tasks/parts/modal/ExperientialTasks.tsx
+++ b/src/pages/Plan/modules/Tasks/parts/modal/ExperientialTasks.tsx
@@ -1,6 +1,7 @@
 import { Button, SM } from '@appquality/unguess-design-system';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as ThinkingAloudTaskIcon } from 'src/assets/icons/thinking-aloud-task-icon.svg';
+import { appTheme } from 'src/app/theme';
 import { useHandleModalItemClick } from '../../utils';
 import { ButtonsContainer } from './ButtonsContainer';
 
@@ -10,8 +11,10 @@ const ExperientialTasks = () => {
 
   return (
     <>
-      <SM isBold>
-        {t('__PLAN_PAGE_MODULE_TASKS_ADD_TASK_MODAL_EXPERIENTIAL_TASKS_LABEL')}
+      <SM isBold color={appTheme.palette.grey[600]}>
+        {t(
+          '__PLAN_PAGE_MODULE_TASKS_ADD_TASK_MODAL_EXPERIENTIAL_TASKS_LABEL'
+        ).toUpperCase()}
       </SM>
       <ButtonsContainer>
         <Button

--- a/src/pages/Plan/modules/Tasks/parts/modal/FunctionalTasks.tsx
+++ b/src/pages/Plan/modules/Tasks/parts/modal/FunctionalTasks.tsx
@@ -2,6 +2,7 @@ import { Button, SM } from '@appquality/unguess-design-system';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as ExploratoryTaskIcon } from 'src/assets/icons/exploratory-task-icon.svg';
 import { ReactComponent as FunctionalTaskIcon } from 'src/assets/icons/functional-task-icon.svg';
+import { appTheme } from 'src/app/theme';
 import { useHandleModalItemClick } from '../../utils';
 import { ButtonsContainer } from './ButtonsContainer';
 
@@ -11,8 +12,10 @@ const FunctionalTasks = () => {
 
   return (
     <>
-      <SM isBold>
-        {t('__PLAN_PAGE_MODULE_TASKS_ADD_TASK_MODAL_FUNCTIONAL_TASKS_LABEL')}
+      <SM isBold color={appTheme.palette.grey[600]}>
+        {t(
+          '__PLAN_PAGE_MODULE_TASKS_ADD_TASK_MODAL_FUNCTIONAL_TASKS_LABEL'
+        ).toUpperCase()}
       </SM>
       <ButtonsContainer>
         <Button

--- a/src/pages/Plan/modules/Tasks/parts/modal/SurveyTasks.tsx
+++ b/src/pages/Plan/modules/Tasks/parts/modal/SurveyTasks.tsx
@@ -1,6 +1,7 @@
 import { Button, SM } from '@appquality/unguess-design-system';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as SurveyTaskIcon } from 'src/assets/icons/survey-task-icon.svg';
+import { appTheme } from 'src/app/theme';
 import { useHandleModalItemClick } from '../../utils';
 import { ButtonsContainer } from './ButtonsContainer';
 
@@ -10,8 +11,10 @@ const SurveyTasks = () => {
 
   return (
     <>
-      <SM isBold>
-        {t('__PLAN_PAGE_MODULE_TASKS_ADD_TASK_MODAL_SURVEY_TASKS_LABEL')}
+      <SM isBold color={appTheme.palette.grey[600]}>
+        {t(
+          '__PLAN_PAGE_MODULE_TASKS_ADD_TASK_MODAL_SURVEY_TASKS_LABEL'
+        ).toUpperCase()}
       </SM>
       <ButtonsContainer>
         <Button


### PR DESCRIPTION
This pull request includes changes to improve the styling of task labels in the modal components for Experiential, Functional, and Survey tasks. The changes ensure that the labels have a consistent color and are displayed in uppercase.

Styling improvements:

* [`src/pages/Plan/modules/Tasks/parts/modal/ExperientialTasks.tsx`](diffhunk://#diff-6c95ef48883962032fd019ff4213d7cf5e1ec2ecb8accd4d49c0211a8f6a5e7dR4): Imported `appTheme` and updated the task label to use `appTheme.palette.grey[600]` color and display in uppercase. [[1]](diffhunk://#diff-6c95ef48883962032fd019ff4213d7cf5e1ec2ecb8accd4d49c0211a8f6a5e7dR4) [[2]](diffhunk://#diff-6c95ef48883962032fd019ff4213d7cf5e1ec2ecb8accd4d49c0211a8f6a5e7dL13-R17)
* [`src/pages/Plan/modules/Tasks/parts/modal/FunctionalTasks.tsx`](diffhunk://#diff-4e4595e9baff1014f83dc26c09429106cc712507103b5d77b954bb04607d7aa6R5): Imported `appTheme` and updated the task label to use `appTheme.palette.grey[600]` color and display in uppercase. [[1]](diffhunk://#diff-4e4595e9baff1014f83dc26c09429106cc712507103b5d77b954bb04607d7aa6R5) [[2]](diffhunk://#diff-4e4595e9baff1014f83dc26c09429106cc712507103b5d77b954bb04607d7aa6L14-R18)
* [`src/pages/Plan/modules/Tasks/parts/modal/SurveyTasks.tsx`](diffhunk://#diff-8ec4056b7ae3407f5a77e61c5487d5d6beac033c26ce0c07f8cf08905ace6e7aR4): Imported `appTheme` and updated the task label to use `appTheme.palette.grey[600]` color and display in uppercase. [[1]](diffhunk://#diff-8ec4056b7ae3407f5a77e61c5487d5d6beac033c26ce0c07f8cf08905ace6e7aR4) [[2]](diffhunk://#diff-8ec4056b7ae3407f5a77e61c5487d5d6beac033c26ce0c07f8cf08905ace6e7aL13-R17)