### PR TITLE
UN-626: adjust displayed bug count in SingleGroupAccordion

### DIFF
--- a/src/pages/Bugs/Content/BugsTable/components/SingleGroupAccordion.tsx
+++ b/src/pages/Bugs/Content/BugsTable/components/SingleGroupAccordion.tsx
@@ -97,7 +97,7 @@ const SingleGroupAccordion = ({
                       style={{ marginRight: appTheme.space.xs }}
                     />
                     {t('__BUGS_PAGE_TABLE_SEE_ALL', 'see all')}
-                    {` (${item.bugs.length})`}
+                    {` (${item.bugs.length - 3})`}
                   </>
                 ) : (
                   <>


### PR DESCRIPTION
This pull request includes a small adjustment to the `SingleGroupAccordion` component in `SingleGroupAccordion.tsx`. The change modifies the bug count displayed in the "see all" text to subtract 3 from the total number of bugs.