### PR TITLE
UN-1264: Fix plans view more behaviour

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1445,7 +1445,7 @@
   "_CAMPAIGN_WIDGET_UX_USER_ANALYSIS_HEADER": "Analyzed User Contributions",
   "_PLAN_PAGE_MODULE_LANGUAGE_DESCRIPTION": "You’ll receive feedback in the language you’re selecting",
   "_PLAN_PAGE_MODULE_LANGUAGE_SUBTITLE": "Select participants' preferred language",
-  "_PROJECT_PAGE_PLANS_GROUP_SEE_ALL": "View all",
+  "_PROJECT_PAGE_PLANS_GROUP_SEE_ALL": "View more",
   "_PROJECT_PAGE_PLANS_GROUP_SEE_LESS": "View less",
   "_PROJECT_PAGE_PLANS_GROUP_SUBTITLE": "Create and configure new activities or review those awaiting approval",
   "_PROJECT_PAGE_PLANS_GROUP_TITLE": "Setup activities",

--- a/src/pages/Dashboard/project-items/Plans.tsx
+++ b/src/pages/Dashboard/project-items/Plans.tsx
@@ -89,9 +89,10 @@ export const Plans = ({ projectId }: { projectId: number }) => {
               {isPreview ? <ChevronDownStroke /> : <ChevronUpStroke />}
             </Button.StartIcon>
             {isPreview
-              ? t('_PROJECT_PAGE_PLANS_GROUP_SEE_ALL')
+              ? `${t('_PROJECT_PAGE_PLANS_GROUP_SEE_ALL')} (${
+                  items.length - PREVIEW_ITEMS_MAX_SIZE
+                })`
               : t('_PROJECT_PAGE_PLANS_GROUP_SEE_LESS')}
-            {` (${items.length})`}
           </Button>
         </ButtonContainer>
       )}

--- a/src/pages/Dashboard/project-items/index.tsx
+++ b/src/pages/Dashboard/project-items/index.tsx
@@ -75,7 +75,7 @@ export const ProjectItems = ({
       <Row
         alignItems="center"
         style={{
-          marginTop: `${theme.space.base * 8}px`,
+          marginTop: `${appTheme.space.xxl}`,
           marginBottom: theme.space.xxs,
         }}
       >


### PR DESCRIPTION
**Also fixes: UN-1102 and UN-1103**

This pull request introduces updates to improve the user interface text, enhance the display of item counts in a button label, and standardize spacing in the project items dashboard. Below is a summary of the key changes:

### User Interface Text Updates:
* Updated the text for the `_PROJECT_PAGE_PLANS_GROUP_SEE_ALL` key in `src/locales/en/translation.json` to "View more" for better alignment with user expectations.

### Functional Enhancements:
* Modified the `Plans` component in `src/pages/Dashboard/project-items/Plans.tsx` to dynamically append the count of additional items (beyond the preview limit) to the "View more" button label, improving clarity for users.

### Styling Improvements:
* Adjusted the `marginTop` property in the `ProjectItems` component in `src/pages/Dashboard/project-items/index.tsx` to use the `appTheme.space.xxl` value, ensuring consistent spacing across the application.