### PR TITLE
Fix observation dropdown placement

### DIFF
--- a/src/pages/Video/components/TitleDropdownNew.tsx
+++ b/src/pages/Video/components/TitleDropdownNew.tsx
@@ -37,6 +37,7 @@ export const TitleDropdown = ({
   return (
     <Field>
       <Autocomplete
+        listboxAppendToNode={document.body}
         isCreatable
         renderValue={({ selection }) => {
           if (!selection) return '';


### PR DESCRIPTION
## Summary
- prevent observation title dropdown from affecting page layout

## Testing
- `yarn lint` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*
- `yarn type:check` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*
- `yarn format:check` *(fails: Error when performing the request to https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6864f3d585a48324937b0faf00e411f6