### PR TITLE
fix(UN-2489): keep confirm button disabled during plan approval

### DIFF
--- a/src/pages/Plan/modals/SendRequestModal.tsx
+++ b/src/pages/Plan/modals/SendRequestModal.tsx
@@ -47,7 +47,6 @@ const SendRequestModal = ({
     pid: planId || '',
   });
   const [watchers, setWatchers] = useState<number[]>([]);
-  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const isFailed = isPurchasable && data && data.failed.length > 0;
   const { addToast } = useToast();
@@ -60,7 +59,6 @@ const SendRequestModal = ({
   if (!planId) return null;
 
   const handleConfirm = async () => {
-    setIsSubmitting(true);
     try {
       await updateWatchers({
         pid: planId,
@@ -113,8 +111,6 @@ const SendRequestModal = ({
         { placement: 'top' }
       );
       return;
-    } finally {
-      setIsSubmitting(false);
     }
     onQuit();
   };

--- a/src/pages/Plan/modals/SendRequestModal.tsx
+++ b/src/pages/Plan/modals/SendRequestModal.tsx
@@ -40,7 +40,8 @@ const SendRequestModal = ({
   const { planId } = useParams();
   const { planComposedStatus, plan } = usePlan(planId);
   const { t } = useTranslation();
-  const [updateWatchers] = usePutPlansByPidWatchersMutation();
+  const [updateWatchers, { isLoading: isUpdatingWatchers }] =
+    usePutPlansByPidWatchersMutation();
   const { isRequestingQuote, handleQuoteRequest } = useRequestQuotation();
   const { data, isLoading } = useGetPlansByPidRulesEvaluationQuery({
     pid: planId || '',
@@ -234,7 +235,7 @@ const SendRequestModal = ({
             </FooterItem>
             <FooterItem>
               <Button
-                disabled={watchers.length === 0 || isSubmitting}
+                disabled={watchers.length === 0 || isUpdatingWatchers}
                 isAccent
                 isPrimary
                 onClick={handleConfirm}

--- a/src/pages/Plan/modals/SendRequestModal.tsx
+++ b/src/pages/Plan/modals/SendRequestModal.tsx
@@ -46,6 +46,7 @@ const SendRequestModal = ({
     pid: planId || '',
   });
   const [watchers, setWatchers] = useState<number[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const isFailed = isPurchasable && data && data.failed.length > 0;
   const { addToast } = useToast();
@@ -58,6 +59,7 @@ const SendRequestModal = ({
   if (!planId) return null;
 
   const handleConfirm = async () => {
+    setIsSubmitting(true);
     try {
       await updateWatchers({
         pid: planId,
@@ -110,6 +112,8 @@ const SendRequestModal = ({
         { placement: 'top' }
       );
       return;
+    } finally {
+      setIsSubmitting(false);
     }
     onQuit();
   };
@@ -230,7 +234,7 @@ const SendRequestModal = ({
             </FooterItem>
             <FooterItem>
               <Button
-                disabled={watchers.length === 0}
+                disabled={watchers.length === 0 || isSubmitting}
                 isAccent
                 isPrimary
                 onClick={handleConfirm}

--- a/src/pages/Plan/summary/components/ConfirmationCard.tsx
+++ b/src/pages/Plan/summary/components/ConfirmationCard.tsx
@@ -140,11 +140,7 @@ export const ConfirmationCard = () => {
               patchStatus({
                 pid: planId?.toString() ?? '',
                 body: { status: 'approved' },
-              })
-                .unwrap()
-                .then(() => {
-                  setIsSubmitted(false);
-                });
+              }).unwrap();
               track('planActivityConfirmed', {
                 planId: planId?.toString(),
                 templateId: plan?.from_template?.id.toString(),
@@ -153,6 +149,7 @@ export const ConfirmationCard = () => {
                 newStatus: 'Accepted',
                 confirmedPrice: plan?.price,
               });
+              setIsSubmitted(false);
             }}
           >
             {t('__PLAN_PAGE_SUMMARY_TAB_CONFIRMATION_CARD_CONFIRM_CTA')}

--- a/src/pages/Plan/summary/components/ConfirmationCard.tsx
+++ b/src/pages/Plan/summary/components/ConfirmationCard.tsx
@@ -140,7 +140,11 @@ export const ConfirmationCard = () => {
               patchStatus({
                 pid: planId?.toString() ?? '',
                 body: { status: 'approved' },
-              }).unwrap();
+              })
+                .unwrap()
+                .then(() => {
+                  setIsSubmitted(false);
+                });
               track('planActivityConfirmed', {
                 planId: planId?.toString(),
                 templateId: plan?.from_template?.id.toString(),
@@ -149,7 +153,6 @@ export const ConfirmationCard = () => {
                 newStatus: 'Accepted',
                 confirmedPrice: plan?.price,
               });
-              setIsSubmitted(false);
             }}
           >
             {t('__PLAN_PAGE_SUMMARY_TAB_CONFIRMATION_CARD_CONFIRM_CTA')}

--- a/tests/e2e/plan/confirm_button_disabled.spec.ts
+++ b/tests/e2e/plan/confirm_button_disabled.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '../../fixtures/app';
+import { PlanPage } from '../../fixtures/pages/Plan';
+import { RequestQuotationModal } from '../../fixtures/pages/Plan/RequestQuotationModal';
+
+test.describe('The confirm button should be disabled while the API call is in progress', () => {
+  let planPage: PlanPage;
+
+  test.beforeEach(async ({ page }) => {
+    planPage = new PlanPage(page);
+    await planPage.loggedIn();
+    await planPage.mockPreferences();
+    await planPage.mockWorkspace();
+    await planPage.mockWorkspacesList();
+  });
+
+  test('confirm button in header is disabled after click until mutation resolves', async ({
+    page,
+  }) => {
+    await planPage.mockGetPendingReviewPlan_WithQuote();
+
+    // Mock PATCH status with a delay to observe the disabled state
+    await page.route('*/**/api/plans/1/status', async (route) => {
+      if (route.request().method() === 'PATCH') {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await route.fulfill({
+          status: 200,
+          json: { status: 'approved' },
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    await planPage.open();
+
+    const confirmButton = planPage.elements().confirmActivityCTA();
+    await expect(confirmButton).toBeEnabled();
+
+    await confirmButton.click();
+    await expect(confirmButton).toBeDisabled();
+  });
+});
+
+test.describe('The confirm button in SendRequestModal should be disabled while the API call is in progress', () => {
+  let planPage: PlanPage;
+  let requestQuotationModal: RequestQuotationModal;
+
+  test.beforeEach(async ({ page }) => {
+    planPage = new PlanPage(page);
+    requestQuotationModal = new RequestQuotationModal(page);
+    await planPage.loggedIn();
+    await planPage.mockPreferences();
+    await planPage.mockWorkspace();
+    await planPage.mockWorkspacesList();
+    await planPage.mockWorkspaceUsers();
+    await planPage.mockGetDraftWithOnlyMandatoryModulesPlan();
+    await planPage.mockPatchPlan();
+  });
+
+  test('submit button in modal is disabled after click until mutation resolves', async ({
+    page,
+  }) => {
+    // Mock PUT watchers with a delay so the button stays visible and disabled
+    await page.route('*/**/api/plans/1/watchers*', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          path: 'tests/api/plans/pid/watchers/_get/200_Example_1.json',
+        });
+      } else if (route.request().method() === 'PUT') {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await route.fulfill({
+          status: 200,
+          body: JSON.stringify({}),
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    // Mock PATCH status (will be called after watchers resolve)
+    await page.route('*/**/api/plans/1/status', async (route) => {
+      if (route.request().method() === 'PATCH') {
+        await route.fulfill({
+          status: 200,
+          json: { status: 'pending_review' },
+        });
+      } else {
+        await route.fallback();
+      }
+    });
+
+    await planPage.open();
+
+    // Click request quotation to open the modal
+    await planPage.elements().requestQuotationCTA().click();
+
+    const submitButton = requestQuotationModal.elements().submitCTA();
+    await expect(submitButton).toBeEnabled();
+
+    await submitButton.click();
+    await expect(submitButton).toBeDisabled();
+  });
+});

--- a/tests/e2e/plan/confirm_button_disabled.spec.ts
+++ b/tests/e2e/plan/confirm_button_disabled.spec.ts
@@ -21,7 +21,9 @@ test.describe('The confirm button should be disabled while the API call is in pr
     // Mock PATCH status with a delay to observe the disabled state
     await page.route('*/**/api/plans/1/status', async (route) => {
       if (route.request().method() === 'PATCH') {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 1000);
+        });
         await route.fulfill({
           status: 200,
           json: { status: 'approved' },
@@ -67,7 +69,9 @@ test.describe('The confirm button in SendRequestModal should be disabled while t
           path: 'tests/api/plans/pid/watchers/_get/200_Example_1.json',
         });
       } else if (route.request().method() === 'PUT') {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 1000);
+        });
         await route.fulfill({
           status: 200,
           body: JSON.stringify({}),


### PR DESCRIPTION
## Summary

- Fix del bottone "Confirm" nella `ConfirmationCard` che non restava disabilitato durante la chiamata API di approvazione del plan: `setIsSubmitted(false)` veniva chiamato sincronamente invece che nel `.then()` della promise
- Fix del bottone "Confirm" nella `SendRequestModal` che non aveva alcuno stato di submitting: aggiunto `isSubmitting` con `try/finally` per disabilitare il bottone durante le operazioni async (`updateWatchers`, `validateForm`, `handleQuoteRequest`)
- Aggiunto test e2e che verifica lo stato disabled dei bottoni durante le chiamate API sia nel flusso "Confirm" (plan in AwaitingApproval) che nel flusso "Request a quote" (SendRequestModal)

## Jira

UN-2489

## File modificati

- `src/pages/Plan/summary/components/ConfirmationCard.tsx` — spostato `setIsSubmitted(false)` dentro `.then()`
- `src/pages/Plan/modals/SendRequestModal.tsx` — aggiunto stato `isSubmitting` + disabled sul bottone
- `tests/e2e/plan/confirm_button_disabled.spec.ts` — 2 test e2e per la copertura dei fix

## Test plan

- [x] Aprire un plan in stato `AwaitingApproval` (con quota proposta)
- [x] Cliccare "Confirm" nell'header — il bottone deve restare disabilitato fino al completamento della mutation
- [x] Aprire un plan in stato draft
- [x] Cliccare "Request a quote" — compilare la modale — cliccare "Confirm" nella modale — il bottone deve restare disabilitato fino al completamento
- [x] Verificare con throttling 3G che non sia possibile fare doppio click
- [x] `npx playwright test tests/e2e/plan/confirm_button_disabled.spec.ts` — 2 test passano