### PR TITLE
feat: add deletePlansByPid endpoint to invalidate Plans tag

### DIFF
--- a/src/features/api/apiTags.ts
+++ b/src/features/api/apiTags.ts
@@ -321,6 +321,9 @@ unguessApi.enhanceEndpoints({
     patchPlansByPidStatus: {
       invalidatesTags: ['Plans', 'Projects', 'CheckoutItem'],
     },
+    deletePlansByPid: {
+      invalidatesTags: ['Plans'],
+    },
     getPlansByPidCheckoutItem: {
       providesTags: ['CheckoutItem'],
     },


### PR DESCRIPTION
This pull request adds a new API endpoint mutation for deleting plans by project ID and ensures that the relevant cache tags are invalidated when this operation occurs.

API endpoint enhancement:

* Added a new `deletePlansByPid` mutation to the API, which invalidates the `Plans` cache tag to keep client data in sync after a plan is deleted.