### PR TITLE
fix: enable Next button on onboarding steps with pre-filled values

### DIFF
--- a/src/pages/JoinPage/OnboardingPage/Steps/PersonalInfoStep.tsx
+++ b/src/pages/JoinPage/OnboardingPage/Steps/PersonalInfoStep.tsx
@@ -75,7 +75,7 @@ const AutofillSync = () => {
       if (
         input &&
         input.value &&
-        input.value !== valuesRef.current[fieldName]
+        input.value !== valuesRef.current[`${fieldName}`]
       ) {
         setFieldValue(fieldName, input.value, true);
       }

--- a/src/pages/JoinPage/OnboardingPage/Steps/PersonalInfoStep.tsx
+++ b/src/pages/JoinPage/OnboardingPage/Steps/PersonalInfoStep.tsx
@@ -275,7 +275,7 @@ export const PersonalInfoStep = () => {
                       <Select
                         placeholder={t('SIGNUP_FORM_ROLE_PLACEHOLDER')}
                         data-qa="roleId-select"
-                        {...field}
+                        name={field.name}
                         inputValue={
                           field.value
                             ? dataRoles?.find(
@@ -295,7 +295,7 @@ export const PersonalInfoStep = () => {
                           </>
                         }
                         onSelect={(roleId) => {
-                          setFieldValue('roleId', Number(roleId));
+                          setFieldValue('roleId', Number(roleId), true);
                           (
                             roleSelectRef.current?.querySelector(
                               '[role="combobox"]'
@@ -327,7 +327,7 @@ export const PersonalInfoStep = () => {
                       <Select
                         placeholder={t('SIGNUP_FORM_COMPANY_SIZE_PLACEHOLDER')}
                         data-qa="companySizeId-select"
-                        {...field}
+                        name={field.name}
                         inputValue={
                           field.value
                             ? dataCompanySizes?.find(
@@ -347,7 +347,7 @@ export const PersonalInfoStep = () => {
                           </>
                         }
                         onSelect={(sizeId) => {
-                          setFieldValue('companySizeId', Number(sizeId));
+                          setFieldValue('companySizeId', Number(sizeId), true);
                           (
                             selectRef.current?.querySelector(
                               '[role="combobox"]'

--- a/src/pages/JoinPage/OnboardingPage/Steps/PersonalInfoStep.tsx
+++ b/src/pages/JoinPage/OnboardingPage/Steps/PersonalInfoStep.tsx
@@ -344,7 +344,6 @@ export const PersonalInfoStep = () => {
                       <Select
                         placeholder={t('SIGNUP_FORM_ROLE_PLACEHOLDER')}
                         data-qa="roleId-select"
-                        name={field.name}
                         inputValue={
                           field.value
                             ? dataRoles?.find(
@@ -396,7 +395,6 @@ export const PersonalInfoStep = () => {
                       <Select
                         placeholder={t('SIGNUP_FORM_COMPANY_SIZE_PLACEHOLDER')}
                         data-qa="companySizeId-select"
-                        name={field.name}
                         inputValue={
                           field.value
                             ? dataCompanySizes?.find(

--- a/src/pages/JoinPage/OnboardingPage/Steps/PersonalInfoStep.tsx
+++ b/src/pages/JoinPage/OnboardingPage/Steps/PersonalInfoStep.tsx
@@ -202,8 +202,9 @@ export const PersonalInfoStep = () => {
         initialValues={initialValues}
         validationSchema={getPersonalInfoValidationSchema(t)}
         onSubmit={handleSubmit}
+        validateOnMount
       >
-        {({ isSubmitting, isValid, dirty, setFieldValue }) => (
+        {({ isSubmitting, isValid, setFieldValue }) => (
           <Form>
             <FieldContainer>
               <Field name="name">
@@ -377,7 +378,7 @@ export const PersonalInfoStep = () => {
                   isAccent
                   isStretched
                   size="medium"
-                  disabled={isSubmitting || !isValid || !dirty}
+                  disabled={isSubmitting || !isValid}
                 >
                   {isSubmitting ? t('LOADING') : t('SIGNUP_FORM_NEXT_STEP')}
                 </Button>

--- a/src/pages/JoinPage/OnboardingPage/Steps/PersonalInfoStep.tsx
+++ b/src/pages/JoinPage/OnboardingPage/Steps/PersonalInfoStep.tsx
@@ -9,8 +9,15 @@ import {
   Span,
   XL,
 } from '@appquality/unguess-design-system';
-import { Field, FieldProps, Form, Formik, FormikHelpers } from 'formik';
-import { useMemo, useRef } from 'react';
+import {
+  Field,
+  FieldProps,
+  Form,
+  Formik,
+  FormikHelpers,
+  useFormikContext,
+} from 'formik';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { appTheme } from 'src/app/theme';
@@ -45,6 +52,67 @@ interface PersonalInfoFormValues {
   roleId: string;
   companySizeId: string;
 }
+
+const TEXT_FIELDS: (keyof PersonalInfoFormValues)[] = ['name', 'surname'];
+
+/**
+ * Syncs browser-autofilled input values into Formik state.
+ * Chrome autofill often skips React synthetic events, leaving Formik
+ * unaware of pre-filled values. This component listens for native DOM
+ * change events (which Chrome does fire for autofill on user interaction)
+ * and pushes them into Formik.
+ */
+const AutofillSync = () => {
+  const { setFieldValue, values } = useFormikContext<PersonalInfoFormValues>();
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+
+  const syncAutofill = useCallback(() => {
+    TEXT_FIELDS.forEach((fieldName) => {
+      const input = document.querySelector<HTMLInputElement>(
+        `input[name="${fieldName}"]`
+      );
+      if (
+        input &&
+        input.value &&
+        input.value !== valuesRef.current[fieldName]
+      ) {
+        setFieldValue(fieldName, input.value, true);
+      }
+    });
+  }, [setFieldValue]);
+
+  // Catch Chrome's delayed native change events for autofilled inputs
+  useEffect(() => {
+    const handleChange = (e: Event) => {
+      const target = e.target as HTMLInputElement;
+      if (
+        target.tagName === 'INPUT' &&
+        target.name &&
+        TEXT_FIELDS.includes(target.name as keyof PersonalInfoFormValues)
+      ) {
+        if (
+          target.value !==
+          valuesRef.current[target.name as keyof PersonalInfoFormValues]
+        ) {
+          setFieldValue(target.name, target.value, true);
+        }
+      }
+    };
+
+    document.addEventListener('change', handleChange, true);
+    return () => document.removeEventListener('change', handleChange, true);
+  }, [setFieldValue]);
+
+  // Also check once shortly after mount for autofill that happened before
+  // any user interaction
+  useEffect(() => {
+    const timer = setTimeout(syncAutofill, 300);
+    return () => clearTimeout(timer);
+  }, [syncAutofill]);
+
+  return null;
+};
 
 export const PersonalInfoStep = () => {
   const { t } = useTranslation();
@@ -206,6 +274,7 @@ export const PersonalInfoStep = () => {
       >
         {({ isSubmitting, isValid, setFieldValue }) => (
           <Form>
+            <AutofillSync />
             <FieldContainer>
               <Field name="name">
                 {({ field, meta }: FieldProps) => {

--- a/src/pages/JoinPage/OnboardingPage/Steps/WorkspaceStep.tsx
+++ b/src/pages/JoinPage/OnboardingPage/Steps/WorkspaceStep.tsx
@@ -155,8 +155,9 @@ export const WorkspaceStep = () => {
         initialValues={initialValues}
         validationSchema={getWorkspaceValidationSchema(t)}
         onSubmit={handleSubmit}
+        validateOnMount
       >
-        {({ isSubmitting, isValid, dirty }) => (
+        {({ isSubmitting, isValid }) => (
           <Form>
             <FieldContainer>
               <Field name="workspace">
@@ -196,7 +197,7 @@ export const WorkspaceStep = () => {
                   isAccent
                   isStretched
                   size="medium"
-                  disabled={isSubmitting || !isValid || !dirty}
+                  disabled={isSubmitting || !isValid}
                 >
                   {isSubmitting ? t('LOADING') : t('SIGNUP_FORM_SUBMIT')}
                 </Button>

--- a/src/pages/Profile/parts/MfaAccordion/steps/AuthenticatorStep.tsx
+++ b/src/pages/Profile/parts/MfaAccordion/steps/AuthenticatorStep.tsx
@@ -63,8 +63,8 @@ export const AuthenticatorStep = ({
       setSecretKey(totpDetails.sharedSecret);
 
       const totpUri = totpDetails.getSetupUri(
-        userEmail || 'UNGUESS',
-        'UNGUESS'
+        'UNGUESS',
+        userEmail || 'UNGUESS'
       );
       const generatedQrCodeUrl = await QRCode.toDataURL(totpUri.href);
       setQrCodeUrl(generatedQrCodeUrl);


### PR DESCRIPTION
Replace Formik's `dirty` check with `validateOnMount` so the Next button activates correctly when navigating back to a previously filled step or when fields are pre-populated for invited users.