### PR TITLE
UN-2680 - feat: move AI task buttons to top of modal for better visibility

### DIFF
--- a/src/pages/Plan/modules/Factory/modules/Tasks/Component/parts/modal/ExperientialTasks.tsx
+++ b/src/pages/Plan/modules/Factory/modules/Tasks/Component/parts/modal/ExperientialTasks.tsx
@@ -1,11 +1,12 @@
 import { Button } from '@appquality/unguess-design-system';
+import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as ThinkingAloudTaskIcon } from 'src/assets/icons/thinking-aloud-task-icon.svg';
 import { useHandleModalItemClick } from '../../utils';
 import { ButtonsContainer } from './ButtonsContainer';
 import { TaskTypeTitle } from './TaskTypeTitle';
 
-const ExperientialTasks = () => {
+const ExperientialTasks = ({ children }: { children?: ReactNode }) => {
   const { t } = useTranslation();
   const handleModalItemClick = useHandleModalItemClick();
 
@@ -16,6 +17,7 @@ const ExperientialTasks = () => {
           '__PLAN_PAGE_MODULE_TASKS_ADD_TASK_MODAL_EXPERIENTIAL_TASKS_LABEL'
         ).toUpperCase()}
       </TaskTypeTitle>
+      {children}
       <ButtonsContainer>
         <Button
           isBasic

--- a/src/pages/Plan/modules/Factory/modules/Tasks/Component/parts/modal/FunctionalTasks.tsx
+++ b/src/pages/Plan/modules/Factory/modules/Tasks/Component/parts/modal/FunctionalTasks.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@appquality/unguess-design-system';
+import { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ReactComponent as ExploratoryTaskIcon } from 'src/assets/icons/exploratory-task-icon.svg';
 import { ReactComponent as FunctionalTaskIcon } from 'src/assets/icons/functional-task-icon.svg';
@@ -6,7 +7,7 @@ import { useHandleModalItemClick } from '../../utils';
 import { ButtonsContainer } from './ButtonsContainer';
 import { TaskTypeTitle } from './TaskTypeTitle';
 
-const FunctionalTasks = () => {
+const FunctionalTasks = ({ children }: { children?: ReactNode }) => {
   const { t } = useTranslation();
   const handleModalItemClick = useHandleModalItemClick();
 
@@ -17,6 +18,7 @@ const FunctionalTasks = () => {
           '__PLAN_PAGE_MODULE_TASKS_ADD_TASK_MODAL_FUNCTIONAL_TASKS_LABEL'
         ).toUpperCase()}
       </TaskTypeTitle>
+      {children}
       <ButtonsContainer>
         <Button
           isBasic

--- a/src/pages/Plan/modules/Factory/modules/Tasks/Component/parts/modal/TasksModal.tsx
+++ b/src/pages/Plan/modules/Factory/modules/Tasks/Component/parts/modal/TasksModal.tsx
@@ -73,6 +73,33 @@ const TasksModal = () => {
         </TooltipModal.Title>
         <Divider />
         <TooltipModal.Body>
+          {variant === 'functional' && (
+            <>
+              <AiGeneratorSection
+                onOpenCreateWithAI={() => setIsOpenCreateTasksWithAIModal(true)}
+              />
+              <Divider />
+            </>
+          )}
+          {variant === 'experiential' && (
+            <>
+              <AiGeneratorSection
+                onOpenCreateWithAI={() =>
+                  setIsOpenCreateVideoTasksWithAIModal(true)
+                }
+                checkApiHealth={false}
+                label={
+                  <Trans
+                    i18nKey="__PLAN_PAGE_MODULE_TASKS_ADD_VIDEO_TASK_MODAL_AI_DISCLAIMER"
+                    components={{
+                      bold: <MD isBold />,
+                    }}
+                  />
+                }
+              />
+              <Divider />
+            </>
+          )}
           <StyledTabs
             {...(hasFeatureFlag(FEATURE_FLAG_CHANGE_MODULES_VARIANTS)
               ? {
@@ -99,9 +126,6 @@ const TasksModal = () => {
             >
               <FunctionalTasks />
               <SurveyTasks />
-              <AiGeneratorSection
-                onOpenCreateWithAI={() => setIsOpenCreateTasksWithAIModal(true)}
-              />
             </StyledTabsPanel>
             <StyledTabsPanel
               key="experiential"
@@ -112,20 +136,6 @@ const TasksModal = () => {
               <ExperientialTasks />
               <Divider />
               <SurveyTasks />
-              <AiGeneratorSection
-                onOpenCreateWithAI={() =>
-                  setIsOpenCreateVideoTasksWithAIModal(true)
-                }
-                checkApiHealth={false}
-                label={
-                  <Trans
-                    i18nKey="__PLAN_PAGE_MODULE_TASKS_ADD_VIDEO_TASK_MODAL_AI_DISCLAIMER"
-                    components={{
-                      bold: <MD isBold />,
-                    }}
-                  />
-                }
-              />
             </StyledTabsPanel>
             <StyledTabsPanel
               key="accessibility"

--- a/src/pages/Plan/modules/Factory/modules/Tasks/Component/parts/modal/TasksModal.tsx
+++ b/src/pages/Plan/modules/Factory/modules/Tasks/Component/parts/modal/TasksModal.tsx
@@ -73,33 +73,6 @@ const TasksModal = () => {
         </TooltipModal.Title>
         <Divider />
         <TooltipModal.Body>
-          {variant === 'functional' && (
-            <>
-              <AiGeneratorSection
-                onOpenCreateWithAI={() => setIsOpenCreateTasksWithAIModal(true)}
-              />
-              <Divider />
-            </>
-          )}
-          {variant === 'experiential' && (
-            <>
-              <AiGeneratorSection
-                onOpenCreateWithAI={() =>
-                  setIsOpenCreateVideoTasksWithAIModal(true)
-                }
-                checkApiHealth={false}
-                label={
-                  <Trans
-                    i18nKey="__PLAN_PAGE_MODULE_TASKS_ADD_VIDEO_TASK_MODAL_AI_DISCLAIMER"
-                    components={{
-                      bold: <MD isBold />,
-                    }}
-                  />
-                }
-              />
-              <Divider />
-            </>
-          )}
           <StyledTabs
             {...(hasFeatureFlag(FEATURE_FLAG_CHANGE_MODULES_VARIANTS)
               ? {
@@ -124,7 +97,15 @@ const TasksModal = () => {
                 '__PLAN_PAGE_MODULE_TASKS_ADD_TASK_MODAL_FUNCTIONAL_TAB'
               )}
             >
-              <FunctionalTasks />
+              <FunctionalTasks>
+                <AiGeneratorSection
+                  onOpenCreateWithAI={() =>
+                    setIsOpenCreateTasksWithAIModal(true)
+                  }
+                />
+                <Divider />
+              </FunctionalTasks>
+              <Divider />
               <SurveyTasks />
             </StyledTabsPanel>
             <StyledTabsPanel
@@ -133,7 +114,23 @@ const TasksModal = () => {
                 '__PLAN_PAGE_MODULE_TASKS_ADD_TASK_MODAL_EXPERIENTIAL_TAB'
               )}
             >
-              <ExperientialTasks />
+              <ExperientialTasks>
+                <AiGeneratorSection
+                  onOpenCreateWithAI={() =>
+                    setIsOpenCreateVideoTasksWithAIModal(true)
+                  }
+                  checkApiHealth={false}
+                  label={
+                    <Trans
+                      i18nKey="__PLAN_PAGE_MODULE_TASKS_ADD_VIDEO_TASK_MODAL_AI_DISCLAIMER"
+                      components={{
+                        bold: <MD isBold />,
+                      }}
+                    />
+                  }
+                />
+                <Divider />
+              </ExperientialTasks>
               <Divider />
               <SurveyTasks />
             </StyledTabsPanel>


### PR DESCRIPTION
## Summary

- Extracted `AiGeneratorSection` fuori dalla zona scrollabile del modal
- Il bottone "Create tasks with AI" appare ora in cima alla modale, immediatamente visibile senza scroll
- Renderizzato condizionalmente in base al variant attivo (`functional` / `experiential`)

## Test plan

- [ ] Aprire la modale task su un modulo con variant `functional` → verificare che il bottone AI sia visibile in cima
- [ ] Aprire la modale task su un modulo con variant `experiential` → verificare che il bottone AI video sia visibile in cima
- [ ] Verificare che nei variant `default` e `accessibility` il bottone AI non compaia
- [ ] Cliccare il bottone e verificare che si apra la modale AI corretta