### PR TITLE
feat(UN-2538): add ?t= parameter to observation share link for video timestamp

### DIFF
--- a/src/pages/Video/components/Observation.tsx
+++ b/src/pages/Video/components/Observation.tsx
@@ -69,7 +69,7 @@ const Observation = ({
     (anchor: string, event: React.MouseEvent) => {
       event.stopPropagation();
       navigator.clipboard.writeText(
-        `${window.location.origin}${pageUrl}#${anchor}`
+        `${window.location.origin}${pageUrl}?t=${Math.floor(start)}#${anchor}`
       );
       addToast(
         ({ close }) => (

--- a/src/pages/Video/components/Observation.tsx
+++ b/src/pages/Video/components/Observation.tsx
@@ -69,7 +69,9 @@ const Observation = ({
     (anchor: string, event: React.MouseEvent) => {
       event.stopPropagation();
       navigator.clipboard.writeText(
-        `${window.location.origin}${pageUrl}?t=${Math.floor(start)}#${anchor}`
+        `${window.location.origin}${pageUrl}${
+          start > 0 ? `?t=${Math.floor(start)}` : ''
+        }#${anchor}`
       );
       addToast(
         ({ close }) => (

--- a/src/pages/Video/useSetStartTimeFromObservation.ts
+++ b/src/pages/Video/useSetStartTimeFromObservation.ts
@@ -4,14 +4,15 @@ function parseTimeParam(t: string): number {
   if (/^\d+$/.test(t)) return parseInt(t, 10);
 
   let total = 0;
-  const hours = t.match(/(\d+)h/);
-  const minutes = t.match(/(\d+)m/);
-  const seconds = t.match(/(\d+)s/);
+  if (!/^[\dhms]+$/.test(t)) return 0;
 
-  if (hours) total += parseInt(hours[1], 10) * 3600;
-  if (minutes) total += parseInt(minutes[1], 10) * 60;
-  if (seconds) total += parseInt(seconds[1], 10);
+  const h = t.match(/(\d+)h/);
+  const m = t.match(/(\d+)m/);
+  const s = t.match(/(\d+)s/);
 
+  if (h) total += parseInt(h[1], 10) * 3600;
+  if (m) total += parseInt(m[1], 10) * 60;
+  if (s) total += parseInt(s[1], 10);
   return total;
 }
 

--- a/src/pages/Video/useSetStartTimeFromObservation.ts
+++ b/src/pages/Video/useSetStartTimeFromObservation.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
+// Accepted: "135" (seconds), "135s", "2m15s", "1h2m3s", "0m135s"
 function parseTimeParam(t: string): number {
   if (/^\d+$/.test(t)) return parseInt(t, 10);
 

--- a/src/pages/Video/useSetStartTimeFromObservation.ts
+++ b/src/pages/Video/useSetStartTimeFromObservation.ts
@@ -1,26 +1,47 @@
 import { useEffect, useMemo } from 'react';
 
-/**
- * Sets the video player's currentTime based on the observation anchor in the URL.
- * @param observations List of observations (array of objects with id and start)
- * @param videoRef Ref to the HTMLVideoElement
- * @returns startTime (number)
- */
+function parseTimeParam(t: string): number {
+  if (/^\d+$/.test(t)) return parseInt(t, 10);
+
+  let total = 0;
+  const hours = t.match(/(\d+)h/);
+  const minutes = t.match(/(\d+)m/);
+  const seconds = t.match(/(\d+)s/);
+
+  if (hours) total += parseInt(hours[1], 10) * 3600;
+  if (minutes) total += parseInt(minutes[1], 10) * 60;
+  if (seconds) total += parseInt(seconds[1], 10);
+
+  return total;
+}
+
 export function useSetStartTimeFromObservation(
   observations: { id: number; start: number }[] | undefined,
   videoRef: React.RefObject<HTMLVideoElement | null>
 ) {
   const startTime = useMemo(() => {
-    const url = window.location.href;
-    const urlAnchor = url.split('#')[1];
-    if (urlAnchor) {
-      const observationId = parseInt(urlAnchor.replace('observation-', ''), 10);
-      return observations?.find((obs) => obs.id === observationId)?.start || 0;
+    const url = new URL(window.location.href);
+
+    const tParam = url.searchParams.get('t');
+    if (tParam) {
+      const seconds = parseTimeParam(tParam);
+      if (seconds > 0) return seconds;
     }
+
+    if (observations) {
+      const urlAnchor = url.hash.replace('#', '');
+      if (urlAnchor) {
+        const observationId = parseInt(
+          urlAnchor.replace('observation-', ''),
+          10
+        );
+        return observations.find((obs) => obs.id === observationId)?.start || 0;
+      }
+    }
+
     return 0;
   }, [observations]);
 
-  // Effect to set the video player's currentTime based only on the startTime, regardless of observations changing
   useEffect(() => {
     if (!videoRef.current) return;
     if (startTime > 0) {


### PR DESCRIPTION
## Panoramica

Aggiunto il parametro \`?t={obs.start}\` al link generato dal bottone "Condividi" di ogni observation nel player video. Aprendo il link condiviso, il player carica il video direttamente al momento in cui inizia l'observation.

Lo start viene arrotondato al secondo per troncamento (\`Math.floor\`),  — la precisione interna è in millisecondi, ma \`3.999s\` e \`3.000009s\` diventano entrambi \`t=3\`.

## Formati supportati dal parametro \`?t\`

| Valore | Comportamento |
|--------|---------------|
| \`?t=135\` | player a 2m 15s |
| \`?t=135s\` | player a 2m 15s |
| \`?t=2m15s\` | player a 2m 15s |
| \`?t=0m135s\` | player a 2m 15s |

## Edge case

| Valore | Comportamento |
|--------|---------------|
| \`?t=-140s\` | player a 0s (valore negativo) |
| \`?t=999999999999999999999s\` | player a 0s (valore superiore alla durata) |
| \`?t=ahsdkbcdfv3565bdkf\` | player a 0s (stringa non parsabile) |

### Caso non gestito

Stringhe alfanumeriche che contengono una sequenza valida al loro interno (es. \`sfndovjdnAAAAAA55sAAAAAAfvdvdv\`) vengono parzialmente parsate e il player va a \`55s\`. Il caso è raro e non si presenta nei link generati dall'applicazione — gestibile con una regex dedicata se necessario.