### PR TITLE
UN-2894 — Subtask 2: campaign overview tab under entity wrapper

### DIFF
--- a/src/features/templates/EntityPageWrapper.tsx
+++ b/src/features/templates/EntityPageWrapper.tsx
@@ -27,7 +27,6 @@ import { useSyncEntityNavigation } from 'src/hooks/useSyncEntityNavigation';
 import { useUseCaseExport } from 'src/hooks/useUseCaseExport';
 import { getLocalizeIntegrationCenterRoute } from 'src/hooks/useLocalizeIntegrationCenterUrl';
 import { ArchiveCampaignModal } from 'src/pages/Campaign/ArchiveCampaignModal';
-import Campaign from 'src/pages/Campaign';
 import {
   MoveCampaignModal,
   MoveCampaignModalContextProvider,
@@ -120,7 +119,10 @@ const EntityPageWrapperInner = () => {
   const hasTaggingToolFeature = hasFeatureFlag(FEATURE_FLAG_TAGGING_TOOL);
   const projectRouteFallback = useLocalizeRoute('projects/0');
   const tabParam = searchParams.get('tab');
-  const shouldUseLegacyPath = !tabParam;
+  // UN-2894: campaign root now enters the wrapper (defaults to the overview
+  // tab, the effect below sets `?tab=overview`). Hub root stays legacy until
+  // UN-2897.
+  const shouldUseLegacyPath = !tabParam && isHub;
 
   const {
     data: userData,
@@ -203,9 +205,9 @@ const EntityPageWrapperInner = () => {
     analyticsCampaignId: !isHub && !shouldUseLegacyPath ? entityId : undefined,
   });
 
-  // UN-2893 scope: keep root legacy content untouched when tab is absent.
+  // Hub root keeps the legacy content until UN-2897.
   if (shouldUseLegacyPath) {
-    return isHub ? <Videos /> : <Campaign />;
+    return <Videos />;
   }
 
   if (isUserLoading || isUserFetching) {

--- a/src/features/templates/entityTabs.ts
+++ b/src/features/templates/entityTabs.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react';
 import type { CampaignHubContext } from './CampaignsHubsMiddleware';
 import type { EntityPageTabId } from './EntityPageHeader';
+import { OverviewTab } from './tabs/OverviewTab';
 
 /**
  * Context exposed to per-tab content via the wrapper `<Outlet>`. Mirrors the
@@ -37,4 +38,10 @@ export interface EntityTabDef {
  * wins. While empty, the wrapper renders no tab body (the shell still falls
  * back to legacy content when `?tab=` is absent).
  */
-export const ENTITY_TABS: EntityTabDef[] = [];
+export const ENTITY_TABS: EntityTabDef[] = [
+  {
+    id: 'overview',
+    match: (ctx) => !ctx.isHub && ctx.activeTab === 'overview',
+    Content: OverviewTab,
+  },
+];

--- a/src/features/templates/tabs/OverviewTab.tsx
+++ b/src/features/templates/tabs/OverviewTab.tsx
@@ -1,0 +1,33 @@
+import { Col, Grid, Row } from '@appquality/unguess-design-system';
+import { useOutletContext } from 'react-router-dom';
+import { LayoutWrapper } from 'src/common/components/LayoutWrapper';
+import { CampaignMetaRow } from 'src/pages/Campaign/CampaignMetaRow';
+import { CampaignWidgets } from 'src/pages/Campaign/CampaignWidgets';
+import styled from 'styled-components';
+import type { EntityTabContext } from '../entityTabs';
+
+const StyledMetaRow = styled(CampaignMetaRow)`
+  margin-bottom: ${({ theme }) => theme.space.md};
+`;
+
+/**
+ * Campaign overview tab body. Reuses the content-only `CampaignWidgets` and a
+ * `CampaignMetaRow` (status/duration/devices) at the top — no legacy page
+ * header is rendered here, the shared `EntityPageHeader` owns it.
+ */
+export const OverviewTab = () => {
+  const { entityId } = useOutletContext<EntityTabContext>();
+
+  return (
+    <LayoutWrapper>
+      <Grid>
+        <Row>
+          <Col>
+            <StyledMetaRow campaignId={entityId} />
+            <CampaignWidgets />
+          </Col>
+        </Row>
+      </Grid>
+    </LayoutWrapper>
+  );
+};

--- a/src/features/templates/tabs/OverviewTab.tsx
+++ b/src/features/templates/tabs/OverviewTab.tsx
@@ -1,4 +1,5 @@
-import { Col, Grid, Row } from '@appquality/unguess-design-system';
+import { getColor, LG } from '@appquality/unguess-design-system';
+import { useTranslation } from 'react-i18next';
 import { useOutletContext } from 'react-router-dom';
 import { LayoutWrapper } from 'src/common/components/LayoutWrapper';
 import { CampaignMetaRow } from 'src/pages/Campaign/CampaignMetaRow';
@@ -6,28 +7,46 @@ import { CampaignWidgets } from 'src/pages/Campaign/CampaignWidgets';
 import styled from 'styled-components';
 import type { EntityTabContext } from '../entityTabs';
 
+// Top padding of the overview section (matches the 32px spacer in the design).
+const Section = styled.div`
+  padding-top: ${({ theme }) => theme.space.lg};
+`;
+
+// Active-tab title shown at the top of the content column, above the meta row.
+const TabTitle = styled(LG)`
+  color: ${({ theme }) => getColor(theme.palette.blue, 600)};
+  margin-bottom: ${({ theme }) => theme.space.xs};
+  padding-bottom: ${({ theme }) => theme.space.xs};
+  border-bottom: 1px solid ${({ theme }) => theme.palette.grey[300]};
+`;
+
 const StyledMetaRow = styled(CampaignMetaRow)`
-  margin-bottom: ${({ theme }) => theme.space.md};
+  margin-bottom: ${({ theme }) => theme.space.lg};
 `;
 
 /**
- * Campaign overview tab body. Reuses the content-only `CampaignWidgets` and a
- * `CampaignMetaRow` (status/duration/devices) at the top — no legacy page
- * header is rendered here, the shared `EntityPageHeader` owns it.
+ * Campaign overview tab body. Reuses the content-only `CampaignWidgets` and
+ * renders, at the top of the content column (aligned with the widgets, not
+ * full-width), the "Overview" title and the `CampaignMetaRow`
+ * (status/duration/devices). No legacy page header is rendered here — the
+ * shared `EntityPageHeader` owns it.
  */
 export const OverviewTab = () => {
+  const { t } = useTranslation();
   const { entityId } = useOutletContext<EntityTabContext>();
 
   return (
     <LayoutWrapper>
-      <Grid>
-        <Row>
-          <Col>
-            <StyledMetaRow campaignId={entityId} />
-            <CampaignWidgets />
-          </Col>
-        </Row>
-      </Grid>
+      <Section>
+        <CampaignWidgets
+          contentHeader={
+            <>
+              <TabTitle isBold>{t('__ENTITY_PAGE_TAB_OVERVIEW')}</TabTitle>
+              <StyledMetaRow campaignId={entityId} />
+            </>
+          }
+        />
+      </Section>
     </LayoutWrapper>
   );
 };

--- a/src/pages/Campaign/CampaignMetaRow.tsx
+++ b/src/pages/Campaign/CampaignMetaRow.tsx
@@ -1,0 +1,70 @@
+import { Skeleton } from '@appquality/unguess-design-system';
+import { StatusMeta } from 'src/common/components/meta/StatusMeta';
+import { PageMeta } from 'src/common/components/PageMeta';
+import { Pipe } from 'src/common/components/Pipe';
+import {
+  useGetCampaignsByCidMetaQuery,
+  useGetCampaignsByCidQuery,
+} from 'src/features/api';
+import { CampaignStatus } from 'src/types';
+import { CampaignDurationMeta } from './pageHeader/Meta/CampaignDurationMeta';
+import { DesktopMeta } from './pageHeader/Meta/DesktopMeta';
+import { SmartphoneMeta } from './pageHeader/Meta/SmartphoneMeta';
+import { TabletMeta } from './pageHeader/Meta/TabletMeta';
+import { TvMeta } from './pageHeader/Meta/TvMeta';
+
+/**
+ * Content-only informational meta row (status, duration, devices) for the
+ * campaign overview. The action buttons that used to live next to this row in
+ * the legacy `Metas` component now belong to the shared `EntityPageHeader`, so
+ * they are intentionally not rendered here.
+ */
+export const CampaignMetaRow = ({
+  campaignId,
+  className,
+}: {
+  campaignId: string;
+  className?: string;
+}) => {
+  const {
+    data: campaign,
+    isLoading: isCampaignLoading,
+    isFetching: isCampaignFetching,
+  } = useGetCampaignsByCidQuery({ cid: campaignId });
+  const {
+    data: meta,
+    isLoading: isMetaLoading,
+    isFetching: isMetaFetching,
+  } = useGetCampaignsByCidMetaQuery({ cid: campaignId });
+
+  if (
+    isCampaignLoading ||
+    isCampaignFetching ||
+    isMetaLoading ||
+    isMetaFetching ||
+    !campaign
+  ) {
+    return <Skeleton width="500px" height="20px" />;
+  }
+
+  const { start_date, end_date, type, status, family } = campaign;
+
+  return (
+    <PageMeta className={className} data-qa="campaign_pageHeader_meta">
+      <StatusMeta status={family.name.toLowerCase() as CampaignStatus}>
+        {type.name}
+      </StatusMeta>
+      <StatusMeta status={status.name as CampaignStatus} />
+      <CampaignDurationMeta start={start_date} end={end_date} />
+      {meta ? (
+        <>
+          <Pipe />
+          {meta.allowed_devices.includes('desktop') && <DesktopMeta />}
+          {meta.allowed_devices.includes('smartphone') && <SmartphoneMeta />}
+          {meta.allowed_devices.includes('tablet') && <TabletMeta />}
+          {meta.allowed_devices.includes('tv') && <TvMeta />}
+        </>
+      ) : null}
+    </PageMeta>
+  );
+};

--- a/src/pages/Campaign/CampaignWidgets.tsx
+++ b/src/pages/Campaign/CampaignWidgets.tsx
@@ -1,4 +1,5 @@
 import { Col, Grid, Row } from '@appquality/unguess-design-system';
+import { type ReactNode } from 'react';
 import {
   AsideNav,
   StickyNavItem,
@@ -10,7 +11,14 @@ import { useEntityId } from 'src/hooks/useEntityId';
 import { EmptyState } from './EmptyState';
 import { useWidgets } from './useWidgets';
 
-export const CampaignWidgets = () => {
+export const CampaignWidgets = ({
+  contentHeader,
+}: {
+  // Optional content rendered at the top of the main content column (aligned
+  // with the widgets, not full-width). Used by the entity overview tab to place
+  // the meta row; the legacy page passes nothing.
+  contentHeader?: ReactNode;
+}) => {
   const resolvedCampaignId = useEntityId();
   const { widgets, isLoading } = useWidgets({
     campaignId: resolvedCampaignId ? Number(resolvedCampaignId) : 0,
@@ -18,7 +26,10 @@ export const CampaignWidgets = () => {
   const { all, footers, items, itemsWithTitles } = widgets;
 
   return all.length === 0 ? (
-    <EmptyState />
+    <>
+      {contentHeader}
+      <EmptyState />
+    </>
   ) : (
     <Grid gutters="xl">
       <Row>
@@ -63,6 +74,7 @@ export const CampaignWidgets = () => {
           </AsideNav>
         </Col>
         <Col xs={12} lg={10}>
+          {contentHeader}
           {items.map((widget) => widget.content)}
         </Col>
       </Row>

--- a/src/pages/Campaign/WidgetSection.tsx
+++ b/src/pages/Campaign/WidgetSection.tsx
@@ -23,7 +23,7 @@ const WidgetGrid = styled.div`
 
 interface WidgetSectionProps {
   id?: string;
-  title: string;
+  title?: string;
   subtitle?: string;
   children?: React.ReactNode;
 }
@@ -35,9 +35,11 @@ const WidgetSectionNew = ({
   children,
 }: WidgetSectionProps) => (
   <section id={id}>
-    <header style={{ marginBottom: appTheme.space.xl }}>
-      <SectionTitle subtitle={subtitle} title={title} />
-    </header>
+    {title && (
+      <header style={{ marginBottom: appTheme.space.xl }}>
+        <SectionTitle subtitle={subtitle} title={title} />
+      </header>
+    )}
     <WidgetGrid>{children}</WidgetGrid>
   </section>
 );

--- a/src/pages/Campaign/useWidgets/Functional/CampaignOverview.tsx
+++ b/src/pages/Campaign/useWidgets/Functional/CampaignOverview.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from 'react-i18next';
 import { Campaign } from 'src/features/api';
 import { useHasOnlyUniqueBugs } from '../../useHasOnlyUniqueBugs';
 import { WidgetSectionNew } from '../../WidgetSection';
@@ -15,14 +14,10 @@ export const CampaignOverview = ({
   id: string;
   campaign: Campaign;
 }) => {
-  const { t } = useTranslation();
   const hasOnlyUniqueBugs = useHasOnlyUniqueBugs(campaign.id);
 
   return (
-    <WidgetSectionNew
-      id={id}
-      title={t('__CAMPAIGN_PAGE_NAVIGATION_BUG_ITEM_OVERVIEW_LABEL')}
-    >
+    <WidgetSectionNew id={id}>
       <Progress campaign={campaign} />
       {hasOnlyUniqueBugs ? (
         <OnlyUniqueBugs campaignId={campaign ? campaign.id : 0} />


### PR DESCRIPTION
Stacked on **UN-2893** (PR #1638). Migrates the campaign overview into the shared entity wrapper (Subtask 2).

## Changes
- `EntityPageContent`: mounts the overview body for campaigns (`!isHub && activeTab === 'overview'`), reusing the content-only `CampaignWidgets` plus a new `CampaignMetaRow` (status/duration/devices, no action buttons — those live in the shared `EntityPageHeader`).
- `CampaignMetaRow`: new content-only metadata row.
- `EntityPageWrapper`: campaign root `/campaigns/:id` now enters the wrapper and defaults to `?tab=overview`; hub root stays on legacy `Videos` until UN-2897.

## Notes
- Rebuilt on top of the rebased UN-2893: this branch previously carried superseded shell commits (an early `add Hubs feature` — closed PR #1635 — and an early header/tab-nav rewrite) which are dropped in favour of UN-2893's finalized shell + #1640's Hubs API.
- lint + type:check pass. Browser smoke (`/campaigns/:id` root → overview, `?tab=overview`) recommended before merge.

## Verify
- `/campaigns/:id` (no tab) redirects to `?tab=overview` and renders the overview under the shared header.
- Hub root `/hubs/:id` still renders legacy Videos content.
- Other tabs render nothing yet (migrated in UN-2895/2896/2897).