### PR TITLE
UN-2896 — Migrazione campaign media-list + insights + redirect

### DIFF
--- a/src/common/Pages.tsx
+++ b/src/common/Pages.tsx
@@ -34,6 +34,7 @@ import { LogoutPage } from 'src/pages/Auth/logout';
 import CampaignsHubsMiddleware from 'src/features/templates/CampaignsHubsMiddleware';
 import EntityPageWrapper from 'src/features/templates/EntityPageWrapper';
 import EntityPageContent from 'src/features/templates/EntityPageContent';
+import { LegacyEntityTabRedirect } from 'src/features/templates/LegacyEntityTabRedirect';
 import { Redirect } from './Redirect';
 
 const Pages = () => {
@@ -102,11 +103,11 @@ const Pages = () => {
                   </Route>
                   <Route
                     path={`/${langPrefix}/campaigns/:entityId/videos`}
-                    element={<Videos />}
+                    element={<LegacyEntityTabRedirect tab="media-list" />}
                   />
                   <Route
                     path={`/${langPrefix}/campaigns/:entityId/insights`}
-                    element={<InsightsPage />}
+                    element={<LegacyEntityTabRedirect tab="insights" />}
                   />
                   <Route
                     path={`/${langPrefix}/campaigns/:entityId/videos/:videoId`}

--- a/src/features/templates/EntityPageWrapper.tsx
+++ b/src/features/templates/EntityPageWrapper.tsx
@@ -180,8 +180,23 @@ const EntityPageWrapperInner = () => {
 
   const { data: workspaceProjectsData } = useActiveWorkspaceProjects();
 
+  // `enabledTabs` is only final once the entity has actually loaded (before
+  // that, `campaign`/`hub` are undefined and `getCampaignTabs`/`getHubTabs`
+  // report a narrower set, e.g. campaign defaults to `['overview']` only).
+  // Gate the URL-correction effect on this so a deep link to a non-default
+  // tab (e.g. `?tab=media-list`) isn't clobbered back to the fallback tab
+  // while data is still in flight.
+  const isEntityDataReady =
+    !isUserLoading &&
+    !isUserFetching &&
+    !!userData &&
+    !!entityId &&
+    !isEntityLoading &&
+    !isEntityError &&
+    (isHub ? !!hub : !!campaign);
+
   useEffect(() => {
-    if (shouldUseLegacyPath || !entityId) return;
+    if (shouldUseLegacyPath || !entityId || !isEntityDataReady) return;
 
     if (tabParam !== activeTab) {
       const nextSearchParams = new URLSearchParams(searchParams);
@@ -191,6 +206,7 @@ const EntityPageWrapperInner = () => {
   }, [
     shouldUseLegacyPath,
     entityId,
+    isEntityDataReady,
     tabParam,
     activeTab,
     searchParams,

--- a/src/features/templates/LegacyEntityTabRedirect.tsx
+++ b/src/features/templates/LegacyEntityTabRedirect.tsx
@@ -1,0 +1,23 @@
+import { Navigate, useParams, useSearchParams } from 'react-router-dom';
+import { useLocalizeRoute } from 'src/hooks/useLocalizedRoute';
+import type { EntityPageTabId } from './EntityPageHeader';
+
+/**
+ * Redirects a retired standalone campaign route (e.g. /campaigns/:id/videos)
+ * to the canonical entity route with the equivalent `?tab=` query param,
+ * merging in any existing query params (filters, etc.) instead of clobbering
+ * them. Campaign-only — hub routes still render their standalone pages
+ * (UN-2897).
+ */
+export const LegacyEntityTabRedirect = ({ tab }: { tab: EntityPageTabId }) => {
+  const { entityId } = useParams<{ entityId: string }>();
+  const [searchParams] = useSearchParams();
+  const entityRoute = useLocalizeRoute(`campaigns/${entityId}`);
+
+  const nextSearchParams = new URLSearchParams(searchParams);
+  nextSearchParams.set('tab', tab);
+
+  return (
+    <Navigate to={`${entityRoute}?${nextSearchParams.toString()}`} replace />
+  );
+};

--- a/src/features/templates/entityTabs.ts
+++ b/src/features/templates/entityTabs.ts
@@ -1,6 +1,8 @@
 import type { ComponentType } from 'react';
 import type { CampaignHubContext } from './CampaignsHubsMiddleware';
 import type { EntityPageTabId } from './EntityPageHeader';
+import { InsightsTab } from './tabs/InsightsTab';
+import { MediaListTab } from './tabs/MediaListTab';
 import { OverviewTab } from './tabs/OverviewTab';
 
 /**
@@ -43,5 +45,15 @@ export const ENTITY_TABS: EntityTabDef[] = [
     id: 'overview',
     match: (ctx) => !ctx.isHub && ctx.activeTab === 'overview',
     Content: OverviewTab,
+  },
+  {
+    id: 'media-list',
+    match: (ctx) => !ctx.isHub && ctx.activeTab === 'media-list',
+    Content: MediaListTab,
+  },
+  {
+    id: 'insights',
+    match: (ctx) => !ctx.isHub && ctx.activeTab === 'insights',
+    Content: InsightsTab,
   },
 ];

--- a/src/features/templates/tabs/InsightsTab.tsx
+++ b/src/features/templates/tabs/InsightsTab.tsx
@@ -1,0 +1,45 @@
+import { getColor, LG } from '@appquality/unguess-design-system';
+import { useTranslation } from 'react-i18next';
+import { InsightContextProvider } from 'src/pages/Insights/InsightContext';
+import InsightsPageContent from 'src/pages/Insights/Content';
+import styled from 'styled-components';
+
+// Top padding of the tab section (matches the 32px spacer used by the other
+// migrated tabs — applies to the whole two-column grid, content + drawer).
+const Section = styled.div`
+  padding-top: ${({ theme }) => theme.space.lg};
+`;
+
+// Active-tab title shown at the top of the content column.
+const TabTitle = styled(LG)`
+  color: ${({ theme }) => getColor(theme.palette.blue, 600)};
+  margin-bottom: ${({ theme }) => theme.space.xs};
+  padding-bottom: ${({ theme }) => theme.space.xs};
+  border-bottom: 1px solid ${({ theme }) => theme.palette.grey[300]};
+`;
+
+/**
+ * Campaign insights tab body. Reuses the content-only `InsightsPageContent`
+ * (already width-managed via its own grid layout) and renders, at the top of
+ * the content column, the "Insights" title. Unlike media-list, the legacy
+ * `InsightsPageHeader` had no real meta-info row of its own — only actions
+ * (settings, dashboard/video-list links, download) already covered by the
+ * shared `EntityPageHeader`, so no dedicated meta-row component is needed
+ * here. No legacy page header is rendered here — the shared `EntityPageHeader`
+ * owns it.
+ */
+export const InsightsTab = () => {
+  const { t } = useTranslation();
+
+  return (
+    <Section>
+      <InsightContextProvider>
+        <InsightsPageContent
+          contentHeader={
+            <TabTitle isBold>{t('__ENTITY_PAGE_TAB_INSIGHTS')}</TabTitle>
+          }
+        />
+      </InsightContextProvider>
+    </Section>
+  );
+};

--- a/src/features/templates/tabs/MediaListTab.tsx
+++ b/src/features/templates/tabs/MediaListTab.tsx
@@ -1,0 +1,49 @@
+import { getColor, LG } from '@appquality/unguess-design-system';
+import { useTranslation } from 'react-i18next';
+import { useOutletContext } from 'react-router-dom';
+import { MediaListMetaRow } from 'src/pages/Campaign/MediaListMetaRow';
+import VideosPageContent from 'src/pages/Videos/Content';
+import styled from 'styled-components';
+import type { EntityTabContext } from '../entityTabs';
+
+// Top padding of the tab section (matches the 32px spacer in the design).
+const Section = styled.div`
+  padding-top: ${({ theme }) => theme.space.lg};
+`;
+
+// Active-tab title shown at the top of the content column, above the meta row.
+const TabTitle = styled(LG)`
+  color: ${({ theme }) => getColor(theme.palette.blue, 600)};
+  margin-bottom: ${({ theme }) => theme.space.xs};
+  padding-bottom: ${({ theme }) => theme.space.xs};
+  border-bottom: 1px solid ${({ theme }) => theme.palette.grey[300]};
+`;
+
+const StyledMetaRow = styled(MediaListMetaRow)`
+  margin-bottom: ${({ theme }) => theme.space.lg};
+`;
+
+/**
+ * Campaign media-list tab body. Reuses the content-only `VideosPageContent`
+ * (already width-managed per branch — grid vs empty state) and renders, at the
+ * top of the content column, the "Media list" title and the
+ * `MediaListMetaRow` (video count/date/devices/severities/status). No legacy
+ * page header is rendered here — the shared `EntityPageHeader` owns it.
+ */
+export const MediaListTab = () => {
+  const { t } = useTranslation();
+  const { entityId } = useOutletContext<EntityTabContext>();
+
+  return (
+    <Section>
+      <VideosPageContent
+        contentHeader={
+          <>
+            <TabTitle isBold>{t('__ENTITY_PAGE_TAB_MEDIA_LIST')}</TabTitle>
+            <StyledMetaRow campaignId={entityId} />
+          </>
+        }
+      />
+    </Section>
+  );
+};

--- a/src/pages/Campaign/MediaListMetaRow.tsx
+++ b/src/pages/Campaign/MediaListMetaRow.tsx
@@ -1,0 +1,189 @@
+import { Skeleton, Span } from '@appquality/unguess-design-system';
+import { useTranslation } from 'react-i18next';
+import { appTheme } from 'src/app/theme';
+import { capitalizeFirstLetter } from 'src/common/capitalizeFirstLetter';
+import { getDeviceIcon } from 'src/common/components/BugDetail/Meta';
+import { Meta } from 'src/common/components/Meta';
+import { StatusMeta } from 'src/common/components/meta/StatusMeta';
+import { PageMeta } from 'src/common/components/PageMeta';
+import { Pipe } from 'src/common/components/Pipe';
+import { formatApiDateShortMonthYear } from 'src/common/date/apiDate';
+import {
+  useGetCampaignsByCidObservationsQuery,
+  useGetCampaignsByCidQuery,
+  useGetCampaignsByCidVideosQuery,
+} from 'src/features/api';
+import { CampaignStatus } from 'src/types';
+import styled from 'styled-components';
+import { getAllSeverityTags } from '../Videos/utils/getSeverityTagsWithCount';
+
+const StyledSkeleton = styled(Skeleton)`
+  margin-right: ${({ theme }) => theme.space.sm};
+`;
+
+const StyledPipe = styled(Pipe)`
+  display: inline;
+`;
+
+const SeveritiesMetaContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const DeviceMetaItem = styled(Span)`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.space.xxs};
+  margin-right: ${({ theme }) => theme.space.sm};
+  color: ${({ theme }) => theme.palette.blue[600]};
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  font-weight: ${({ theme }) => theme.fontWeights.medium};
+
+  > svg {
+    width: 16px;
+    height: 16px;
+  }
+`;
+
+const DeviceMetaCount = styled(Span)`
+  color: ${({ theme }) => theme.palette.grey[700]};
+`;
+
+/**
+ * Content-only informational meta row (video count, date, devices, severities,
+ * status) for the campaign media-list tab. The action buttons that used to
+ * live next to this row in the legacy `Metas` component now belong to the
+ * shared `EntityPageHeader`, so they are intentionally not rendered here.
+ */
+export const MediaListMetaRow = ({
+  campaignId,
+  className,
+}: {
+  campaignId: string;
+  className?: string;
+}) => {
+  const { t } = useTranslation();
+
+  const {
+    data: campaign,
+    isLoading: isCampaignLoading,
+    isFetching: isCampaignFetching,
+  } = useGetCampaignsByCidQuery({ cid: campaignId });
+
+  const {
+    data: videos,
+    isLoading: isVideosLoading,
+    isFetching: isFetchingVideos,
+  } = useGetCampaignsByCidVideosQuery({ cid: campaignId });
+
+  const {
+    data: observations,
+    isLoading: isLoadingObservations,
+    isFetching: isFetchingObservations,
+  } = useGetCampaignsByCidObservationsQuery({ cid: campaignId });
+
+  if (
+    isCampaignLoading ||
+    isCampaignFetching ||
+    (isVideosLoading && !videos) ||
+    (isLoadingObservations && !observations) ||
+    !campaign
+  ) {
+    return <Skeleton width="500px" height="20px" />;
+  }
+
+  const { status, start_date } = campaign;
+  const totalVideos = videos?.items.length ?? 0;
+
+  const deviceCounts = (videos?.items || []).reduce(
+    (acc, video) => {
+      const formFactor = video.device?.formFactor;
+
+      if (formFactor === 'desktop') {
+        acc.desktop += 1;
+      } else if (formFactor === 'smartphone') {
+        acc.smartphone += 1;
+      } else if (formFactor === 'tablet') {
+        acc.tablet += 1;
+      } else {
+        acc.unknown += 1;
+      }
+
+      return acc;
+    },
+    { desktop: 0, smartphone: 0, tablet: 0, unknown: 0 }
+  );
+
+  const deviceMetas = [
+    {
+      key: 'desktop',
+      label: t('__VIDEOS_LIST_DESKTOP_TITLE'),
+      count: deviceCounts.desktop,
+    },
+    {
+      key: 'smartphone',
+      label: t('__VIDEOS_LIST_SMARTPHONE_TITLE'),
+      count: deviceCounts.smartphone,
+    },
+    {
+      key: 'tablet',
+      label: t('__VIDEOS_LIST_TABLET_TITLE'),
+      count: deviceCounts.tablet,
+    },
+    {
+      key: 'unknown',
+      label: t('__VIDEOS_LIST_UNKNOWN_DEVICE_TITLE'),
+      count: deviceCounts.unknown,
+    },
+  ].filter((item) => item.count > 0);
+
+  const severities = observations ? getAllSeverityTags(observations) : [];
+
+  return (
+    <PageMeta className={className} data-qa="media_list_tab_meta">
+      <Span isBold style={{ color: appTheme.palette.blue[600] }}>
+        {totalVideos}{' '}
+        {t('__VIDEOS_LIST_META_VIDEO_COUNT', { count: totalVideos })}
+      </Span>
+      {start_date && (
+        <Span style={{ color: appTheme.palette.grey[700] }}>
+          {formatApiDateShortMonthYear(start_date)}
+        </Span>
+      )}
+      {isFetchingVideos ? (
+        <StyledSkeleton width="400px" height="20px" />
+      ) : (
+        <>
+          {deviceMetas.length > 0 && (
+            <StyledPipe style={{ paddingLeft: appTheme.space.sm }} />
+          )}
+          {deviceMetas.map((deviceMeta) => (
+            <DeviceMetaItem key={deviceMeta.key}>
+              {getDeviceIcon(deviceMeta.key)}
+              {deviceMeta.label}{' '}
+              <DeviceMetaCount>{deviceMeta.count}</DeviceMetaCount>
+            </DeviceMetaItem>
+          ))}
+        </>
+      )}
+      {totalVideos > 0 && severities.length > 0 && <StyledPipe />}
+      {isFetchingObservations ? (
+        <StyledSkeleton width="400px" height="20px" />
+      ) : (
+        <SeveritiesMetaContainer>
+          {severities.map((severity) => (
+            <Meta
+              key={severity.name}
+              size="large"
+              color={severity.style}
+              secondaryText={severity.count}
+            >
+              {capitalizeFirstLetter(severity.name)}
+            </Meta>
+          ))}
+        </SeveritiesMetaContainer>
+      )}
+      <StatusMeta status={status.name as CampaignStatus} />
+    </PageMeta>
+  );
+};

--- a/src/pages/Insights/Content.tsx
+++ b/src/pages/Insights/Content.tsx
@@ -1,3 +1,4 @@
+import { type ReactNode } from 'react';
 import { LayoutWrapper } from 'src/common/components/LayoutWrapper';
 import { styled } from 'styled-components';
 import { ActionBar } from './ActionBar';
@@ -26,13 +27,21 @@ const DrawerWrapper = styled.aside`
   align-items: start;
 `;
 
-const InsightsPageContent = () => {
+const InsightsPageContent = ({
+  contentHeader,
+}: {
+  // Optional content rendered at the top of the content column (aligned with
+  // the action bar/widgets/collection, not full-width). Used by the entity
+  // insights tab to place the tab title; the legacy page passes nothing.
+  contentHeader?: ReactNode;
+}) => {
   const { isDrawerOpen } = useInsightContext();
 
   return (
     <FormProvider>
       <Grid isDrawerOpen={isDrawerOpen}>
         <LayoutWrapper isNotBoxed>
+          {contentHeader}
           <ActionBar />
           <Widgets />
           <Collection />

--- a/src/pages/Videos/Content.tsx
+++ b/src/pages/Videos/Content.tsx
@@ -7,7 +7,7 @@ import {
   Tag,
 } from '@appquality/unguess-design-system';
 import { ReactComponent as PlayIcon } from '@zendeskgarden/svg-icons/src/16/play-circle-stroke.svg';
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOutletContext } from 'react-router-dom';
 import { appTheme } from 'src/app/theme';
@@ -31,7 +31,14 @@ const AccordionFooter = styled.div`
   align-items: center;
 `;
 
-const VideosPageContent = () => {
+const VideosPageContent = ({
+  contentHeader,
+}: {
+  // Optional content rendered at the top of the content column (aligned with
+  // the video grid/empty state, not full-width). Used by the entity media-list
+  // tab to place the tab title + meta row; the legacy page passes nothing.
+  contentHeader?: ReactNode;
+}) => {
   const { t } = useTranslation();
 
   const { isHub, entityId } = useOutletContext<CampaignHubContext>();
@@ -57,9 +64,15 @@ const VideosPageContent = () => {
   return (
     <>
       {!videos || totalVideos === 0 ? (
-        <Empty onOpenImportMediaModal={() => setIsImportMediaModalOpen(true)} />
+        <>
+          {contentHeader}
+          <Empty
+            onOpenImportMediaModal={() => setIsImportMediaModalOpen(true)}
+          />
+        </>
       ) : (
         <LayoutWrapper isNotBoxed>
+          {contentHeader}
           <div style={{ opacity: isFetching ? 0.5 : 1 }}>
             <Grid>
               {!!usecases?.length && (


### PR DESCRIPTION
## Summary
- Register campaign `media-list` and `insights` tabs in the `ENTITY_TABS`
  registry (`MediaListTab`, `InsightsTab`), reusing the existing content-only
  `VideosPageContent`/`InsightsPageContent` via a new `contentHeader` slot.
- Extract `MediaListMetaRow` (video count/date/devices/severities/status),
  campaign-only, mirroring the `CampaignMetaRow` pattern from UN-2894.
- Activate legacy redirects `/campaigns/:id/videos` and
  `/campaigns/:id/insights` to the canonical `?tab=` entity route, merging
  existing query params. Hub routes are untouched (UN-2897).
- Fix a race in `EntityPageWrapper` where a deep link to a non-default tab
  was clobbered back to the fallback tab before entity data finished loading.

## Test plan
- [x] `yarn type:check` / `yarn lint` clean
- [x] Manual verification on a real campaign: media-list and insights tabs
      render correctly with title + meta row, no console errors
- [x] Deep link to `?tab=media-list` / `?tab=insights` lands correctly on
      fresh page load (previously reset to overview)
- [x] `/campaigns/:id/videos` and `/campaigns/:id/insights` redirect
      correctly, preserving existing query params
- [x] Hub routes (`/hubs/:id`) unaffected — still render legacy standalone page