### PR TITLE
fix: apply consistent LayoutWrapper padding to hub empty states (UN-2…

### DIFF
--- a/src/features/templates/tabs/HubInsightsTab.tsx
+++ b/src/features/templates/tabs/HubInsightsTab.tsx
@@ -6,6 +6,7 @@ import {
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useOutletContext } from 'react-router-dom';
+import { LayoutWrapper } from 'src/common/components/LayoutWrapper';
 import { useGetCampaignsByCidObservationsQuery } from 'src/features/api';
 import { HubInsightsEmptyState } from 'src/pages/Insights/HubInsightsEmptyState';
 import { InsightContextProvider } from 'src/pages/Insights/InsightContext';
@@ -54,7 +55,12 @@ export const HubInsightsTab = () => {
 
   const renderBody = () => {
     if (isLoading) {
-      return <Skeleton height="200px" style={{ borderRadius: 0 }} />;
+      return (
+        <LayoutWrapper isNotBoxed>
+          <TabTitle>{t('__ENTITY_PAGE_TAB_INSIGHTS')}</TabTitle>
+          <Skeleton height="200px" style={{ borderRadius: 0 }} />
+        </LayoutWrapper>
+      );
     }
 
     if (hasObservations) {
@@ -72,7 +78,11 @@ export const HubInsightsTab = () => {
     // Empty state (no observations): no tab title — the hub empty state is
     // shown clean (product decision), which also avoids the misaligned bare
     // title that rendering it outside the content column would produce.
-    return <HubInsightsEmptyState />;
+    return (
+      <LayoutWrapper isNotBoxed>
+        <HubInsightsEmptyState />
+      </LayoutWrapper>
+    );
   };
 
   return <TabSection>{renderBody()}</TabSection>;

--- a/src/pages/Videos/Content.tsx
+++ b/src/pages/Videos/Content.tsx
@@ -71,14 +71,12 @@ const VideosPageContent = ({
     : [];
 
   return !videos || totalVideos === 0 ? (
-    <>
+    <LayoutWrapper isNotBoxed>
       {/* Hub tabs hide the title/meta in the empty state (product decision);
           campaigns keep it, aligned to the content column. */}
-      {!isHub && contentHeader && (
-        <LayoutWrapper isNotBoxed>{contentHeader}</LayoutWrapper>
-      )}
+      {!isHub && contentHeader}
       <Empty onOpenImportMediaModal={openImportMediaModal} />
-    </>
+    </LayoutWrapper>
   ) : (
     <LayoutWrapper isNotBoxed>
       {contentHeader}


### PR DESCRIPTION
…897)

Both the media-list and insights hub tabs rendered their empty state outside of LayoutWrapper, unlike the populated branch — leaving the empty-state graphic/CTA (and, for insights, the tab title too) flush against the page edge instead of matching the horizontal inset used everywhere else. Wrap the empty (and loading) branches in the same LayoutWrapper isNotBoxed used by the populated content, and route the insights tab title through InsightsPageContent's contentHeader so it gets the same treatment in all three states.