### PR TITLE
fix: normalize email in workspace, project, and campaign invite forms

### DIFF
--- a/src/common/components/inviteUsers/campaignSettings.tsx
+++ b/src/common/components/inviteUsers/campaignSettings.tsx
@@ -15,6 +15,7 @@ import { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useAppSelector } from 'src/app/hooks';
 import { appTheme } from 'src/app/theme';
+import { normalizeEmail } from 'src/common/normalizeEmail';
 import { ReactComponent as CampaignsIcon } from 'src/assets/icons/campaign-icon.svg';
 import { ReactComponent as ProjectsIcon } from 'src/assets/icons/project-icon.svg';
 import { ReactComponent as UsersIcon } from 'src/assets/icons/users-share.svg';
@@ -155,7 +156,7 @@ export const CampaignSettings = ({ dataQa }: { dataQa?: string }) => {
     addNewMember({
       cid: entityId,
       body: {
-        email: values.email,
+        email: normalizeEmail(values.email),
         redirect_url: entityRoute,
         ...(values.message && { message: values.message }),
       },

--- a/src/common/components/inviteUsers/projectSettings.tsx
+++ b/src/common/components/inviteUsers/projectSettings.tsx
@@ -15,6 +15,7 @@ import { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useAppSelector } from 'src/app/hooks';
 import { appTheme } from 'src/app/theme';
+import { normalizeEmail } from 'src/common/normalizeEmail';
 import { ReactComponent as ProjectsIcon } from 'src/assets/icons/project-icon.svg';
 import { ReactComponent as UsersIcon } from 'src/assets/icons/users-share.svg';
 import { ReactComponent as WorkspacesIcon } from 'src/assets/icons/workspace-icon.svg';
@@ -100,7 +101,7 @@ export const ProjectSettings = () => {
     addNewMember({
       pid: projectId?.toString() || '0',
       body: {
-        email: values.email,
+        email: normalizeEmail(values.email),
         redirect_url: projectRoute,
         ...(values.message && { message: values.message }),
       },

--- a/src/common/components/inviteUsers/workspaceSettings.tsx
+++ b/src/common/components/inviteUsers/workspaceSettings.tsx
@@ -13,6 +13,7 @@ import { FormikHelpers } from 'formik';
 import { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { appTheme } from 'src/app/theme';
+import { normalizeEmail } from 'src/common/normalizeEmail';
 import { ReactComponent as UsersIcon } from 'src/assets/icons/users-share.svg';
 import { ReactComponent as WorkspacesIcon } from 'src/assets/icons/workspace-icon.svg';
 import {
@@ -73,7 +74,7 @@ export const WorkspaceSettings = () => {
     addNewMember({
       wid: activeWorkspace?.id.toString() || '',
       body: {
-        email: values.email,
+        email: normalizeEmail(values.email),
         ...(values.message && { message: values.message }),
       },
     })


### PR DESCRIPTION
This pull request updates the user invitation flow to ensure that all email addresses are normalized before being sent to the backend when adding new members to campaigns, projects, and workspaces. The normalization is achieved by applying the `normalizeEmail` utility function to the email input in all relevant settings components.

**Email normalization improvements:**

* `campaignSettings.tsx`, `projectSettings.tsx`, `workspaceSettings.tsx`: Imported the `normalizeEmail` utility and updated the user invitation logic to normalize email addresses before submitting them to the backend. [[1]](diffhunk://#diff-b0a7e07e2d25683a0b365a9882881647bec95efa1a207d16c08145cceb692c8bR18) [[2]](diffhunk://#diff-b0a7e07e2d25683a0b365a9882881647bec95efa1a207d16c08145cceb692c8bL158-R159) [[3]](diffhunk://#diff-6511eaf292aab5a2ffe84f411ebf911cf7ef4bafd7e0d5aa7d796679d030a3daR18) [[4]](diffhunk://#diff-6511eaf292aab5a2ffe84f411ebf911cf7ef4bafd7e0d5aa7d796679d030a3daL103-R104) [[5]](diffhunk://#diff-3c544487cd373956bcbd0d22ce2916565f0e08ecc68943aa47eeb0c33eedb3c5R16) [[6]](diffhunk://#diff-3c544487cd373956bcbd0d22ce2916565f0e08ecc68943aa47eeb0c33eedb3c5L76-R77)